### PR TITLE
修复无法触发legend-item:click事件的bug

### DIFF
--- a/src/legend/category.js
+++ b/src/legend/category.js
@@ -405,6 +405,8 @@ class Category extends Legend {
       checked: item.checked
     });
 
+    // @2018-10-20 by blue.lb 需要设置viewId，否则在emit的时候，parent获取不到viewId
+    itemGroup.set('viewId', this.get('viewId'));
     const textStyle = this.get('textStyle');
     const wordSpace = this.get('_wordSpaceing');
     let startX = 0;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
问题描述：https://riddle.alibaba-inc.com/riddles/d4701fe3
由于legendGroup缺少viewId字段，导致在https://github.com/antvis/g2/blob/97a67f1626e41fcf663f864763b7c1fa42ca66f8/src/chart/view.js#L273
时，无法正确比较
修复方案：
增加set方法将viewId填充到legendGroup属性上