### PR TITLE
修复传入axis中label的textStyle的rotate只有第一个字段生效的bug

### DIFF
--- a/src/label/base.js
+++ b/src/label/base.js
@@ -374,7 +374,9 @@ class Label extends Component {
     return container;
   }
   // 分html dom和G shape两种情况生成label实例
-  _createText(cfg) {
+  _createText(config) {
+    // @2018-11-29 by blue.lb 这里由于使用delete导致之后的配置无法获取到point和rotate，出现问题，深拷贝一次比较好
+    let cfg = Util.deepMix({}, config);
     let container = this.get('container');
     const capture = typeof cfg.capture === 'undefined' ? this.get('capture') : cfg.capture;
     let labelShape;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
Fix https://github.com/antvis/g2/issues/1069