### PR TITLE
fix(HtmlTooltip): 在特定场景下HtmlTooltip.hide()时大概率获取不到container

### DIFF
--- a/src/tooltip/html.js
+++ b/src/tooltip/html.js
@@ -161,26 +161,30 @@ class HtmlTooltip extends Tooltip {
 
   show() {
     const container = this.get('container');
-    container.style.visibility = 'visible';
-    container.style.display = 'block';
-    const crosshairGroup = this.get('crosshairGroup');
-    crosshairGroup && crosshairGroup.show();
-    const markerGroup = this.get('markerGroup');
-    markerGroup && markerGroup.show();
-    super.show();
-    this.get('canvas').draw();
+    if (container && container.style) {
+      container.style.visibility = 'visible';
+      container.style.display = 'block';
+      const crosshairGroup = this.get('crosshairGroup');
+      crosshairGroup && crosshairGroup.show();
+      const markerGroup = this.get('markerGroup');
+      markerGroup && markerGroup.show();
+      super.show();
+      this.get('canvas').draw();
+    }
   }
 
   hide() {
     const container = this.get('container');
-    container.style.visibility = 'hidden';
-    container.style.display = 'none';
-    const crosshairGroup = this.get('crosshairGroup');
-    crosshairGroup && crosshairGroup.hide();
-    const markerGroup = this.get('markerGroup');
-    markerGroup && markerGroup.hide();
-    super.hide();
-    this.get('canvas').draw();
+    if (container && container.style) {
+      container.style.visibility = 'hidden';
+      container.style.display = 'none';
+      const crosshairGroup = this.get('crosshairGroup');
+      crosshairGroup && crosshairGroup.hide();
+      const markerGroup = this.get('markerGroup');
+      markerGroup && markerGroup.hide();
+      super.hide();
+      this.get('canvas').draw();
+    }
   }
 
   destroy() {


### PR DESCRIPTION
---

## 复现场景:

setInterval 1000秒调用chart.changeData(data)时, 同时在canvas中高频率的滚动鼠标滚轮和移动鼠标指针

## 报错信息:

```
g2.js:38493 Uncaught TypeError: Cannot read property 'style' of undefined
    at HtmlTooltip.hide (g2.js:38493)
    at TooltipController.hideTooltip (g2.js:44215)
    at TooltipController.showTooltip (g2.js:44453)
    at TooltipController.onMouseMove (g2.js:44235)
    at Chart.method (g2.js:30471)
    at Chart.emitEvent (g2.js:6533)
    at Chart.emit (g2.js:6561)
    at EventController.onMove (g2.js:44673)
    at Canvas.method (g2.js:30471)
    at Canvas.emitEvent (g2.js:6533)
    at Canvas.emit (g2.js:6561)
    at Canvas._triggerEvent (g2.js:23450)
    at HTMLCanvasElement.<anonymous> (g2.js:23476)
```
---

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->

分别在show和hide函数中添加container && container.style空值判断语句