### PR TITLE
fix(legend): when there are more than 1 chart in one page, legendWrap…

### DIFF
--- a/src/legend/cat-page-html.js
+++ b/src/legend/cat-page-html.js
@@ -6,7 +6,6 @@ const {
 
 const DomUtil = Util.DomUtil;
 const LIST_CLASS = 'g2-legend-list';
-const CONTAINER_CLASS = 'g2-legend';
 const SLIP_CLASS = 'g2-slip';
 const CARET_UP_CLASS = 'g2-caret-up';
 const CARET_DOWN_CLASS = 'g2-caret-down';
@@ -91,7 +90,7 @@ class CatPageHtml extends CatHtml {
   }
 
   _renderFlipPage() {
-    const legendWrapper = document.getElementsByClassName(CONTAINER_CLASS)[0];
+    const legendWrapper = this.get('legendWrapper');
     // ul
     const itemListDom = findNodeByClass(legendWrapper, LIST_CLASS);
 


### PR DESCRIPTION
…per should find the chart it belongs to rather than the page first one

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
When there are more than one cat-page-html legend which need flipPage in one page, it will get unexpected performance in case of ```document.getElementsByClassName(CONTAINER_CLASS)[0];```. It shouldn't get only the page's first container rather than get it's own container at cat-html's method _renderHTML set(legendWrapper).
I'm really looking forward to you can publish new version to fix this bug & horizontal legend style bug.
Thank you.
