### PR TITLE
feature: 支持设置geom中tooltip对应点的形状

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 
 node_js:
   - "8"
+  - "10"
 
 env:
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ addons:
   apt:
     packages:
       - xvfb
+      - libgconf
 
 install:
   - export DISPLAY=':99.0'

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
   apt:
     packages:
       - xvfb
-      - libgconf
+      - libgconf-2-4
 
 install:
   - export DISPLAY=':99.0'

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "connect": "~3.6.6",
     "d3-queue": "~3.0.7",
     "debug": "~3.1.0",
-    "electron": "~2.0.2",
+    "electron": "~4.1.0",
     "eslint": "~3.19.0",
     "eslint-config-airbnb": "~15.0.1",
     "eslint-config-egg": "~4.2.0",

--- a/src/tooltip/canvas.js
+++ b/src/tooltip/canvas.js
@@ -294,8 +294,10 @@ class CanvasTooltip extends Tooltip {
     if (item.marker) {
       const markerAttrs = Util.mix({}, item.marker, {
         x: item.marker.radius / 2,
-        y: 0
+        y: 0,
+        symbol: item.marker.activeSymbol || item.marker.symbol
       });
+
       group.addShape('marker', {
         attrs: markerAttrs
       });

--- a/src/tooltip/mixin/marker-group.js
+++ b/src/tooltip/mixin/marker-group.js
@@ -23,7 +23,9 @@ const MarkerGroupMixin = {
           shadowColor: item.color
         }, markerCfg, {
           x: item.x,
-          y: item.y
+          y: item.y,
+          // geom 对应的tooltip marker
+          symbol: item.marker && item.marker.activeSymbol
         })
       });
     });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
* tooltip中的marker 改成使用svg实现，这样可以渲染常见的图标
* tooltip中能够读取activeSymbol / symbol，来渲染图形对应的图标

[g2 相关PR](https://github.com/antvis/g2/pull/1359) 

![image](https://user-images.githubusercontent.com/6111424/61929480-be64f080-afad-11e9-99f3-48d41b5e5240.png)

