### PR TITLE
fix(tooltip): fix position property when use htmlContent for tooltip

### DIFF
--- a/src/tooltip/html.js
+++ b/src/tooltip/html.js
@@ -118,6 +118,7 @@ class HtmlTooltip extends Tooltip {
       const outterNode = self.get('canvas').get('el').parentNode;
       const container = self._getHtmlContent();
       outterNode.appendChild(container);
+      DomUtil.modifyCSS(container, self.style[CONTAINER_CLASS]);
       self.set('container', container);
     } else {
       self._renderTpl();


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `npm test` passes
- [ ] tests and/or benchmarks are included
- [X] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->

见 [G2 issue 1349](https://github.com/antvis/g2/issues/1349)，在使用 `htmlContent` 属性自定义 tooltip 的时候，css 样式不对
