### PR TITLE
fix(axis): 修复坐标轴 title offset 无法生效的问题

### DIFF
--- a/src/axis/base.ts
+++ b/src/axis/base.ts
@@ -82,7 +82,6 @@ abstract class AxisBase<T extends AxisBaseCfg = AxisBaseCfg> extends GroupCompon
             fontFamily: Theme.fontFamily,
             textAlign: 'center',
           },
-          offset: 48,
         },
         tickStates: {
           active: {

--- a/src/axis/line.ts
+++ b/src/axis/line.ts
@@ -1,6 +1,6 @@
 import { IGroup } from '@antv/g-base';
 import { vec2 } from '@antv/matrix-util';
-import { each, isFunction, isNumberEqual } from '@antv/util';
+import { each, isFunction, isNumberEqual, isNil } from '@antv/util';
 import { ILocation } from '../interfaces';
 import { BBox, LineAxisCfg, Point, RegionLocationCfg } from '../types';
 import AxisBase from './base';
@@ -128,7 +128,10 @@ class Line extends AxisBase<LineAxisCfg> implements ILocation<RegionLocationCfg>
       // 调整 title 的 offset
       const bbox = labelGroup.getBBox();
       const length = isVertical ? bbox.width : bbox.height;
-      titleCfg.offset = labelOffset + length + titleSpacing + titleHeight / 2;
+      if (isNil(titleCfg.offset)) {
+        // 如果用户没有设置 offset，则自动计算
+        titleCfg.offset = labelOffset + length + titleSpacing + titleHeight / 2;
+      }
     }
   }
 

--- a/tests/unit/axis/circle-spec.ts
+++ b/tests/unit/axis/circle-spec.ts
@@ -85,6 +85,7 @@ describe('test line axis', () => {
       },
     });
     expect(axis.getElementById('a-axis-title')).not.toBeUndefined();
+    expect(axis.get('title').offset).toBe(10);
     axis.update({
       title: null,
     });

--- a/tests/unit/axis/line-spec.ts
+++ b/tests/unit/axis/line-spec.ts
@@ -64,6 +64,7 @@ describe('test line axis', () => {
 
     const title = axis.getElementById('a-axis-title');
     expect(title.attr('matrix')).not.toBe(null);
+    expect(axis.get('title').offset).not.toBeUndefined();
   });
 
   it('update label', () => {
@@ -88,9 +89,11 @@ describe('test line axis', () => {
     axis.update({
       title: {
         autoRotate: false,
+        offset: 32,
       },
     });
     expect(title.attr('matrix')).toBe(null);
+    expect(axis.get('title').offset).toBe(32);
     // 不再显示 title
     axis.update({
       title: null,


### PR DESCRIPTION
默认 title 的 offset 自动计算，当用户设置了则以用户值为准。

关联 G2 issue: https://github.com/antvis/G2/issues/2412