### PR TITLE
fix(trend): 修复趋势图中,面积绘制不正确的问题

### DIFF
--- a/src/trend/path.ts
+++ b/src/trend/path.ts
@@ -79,16 +79,33 @@ export function dataToPath(data: number[], width: number, height: number, smooth
 }
 
 /**
+ * 获得 area 面积的横向连接线的 px 位置
+ * @param data 
+ * @param width 
+ * @param height 
+ */
+export function getAreaLineY(data: number[], height: number): number {
+  const y = new Linear({
+    values: data,
+  });
+
+  const lineY = Math.max(0, y.min);
+  return height - y.scale(lineY) * height;
+}
+
+/**
  * 线 path 转 area path
  * @param path
  * @param width
  * @param height
  */
-export function linePathToAreaPath(path: any[][], width: number, height: number): any[][] {
+export function linePathToAreaPath(path: any[][], width: number, height: number, data: number[]): any[][] {
   const areaPath = [...path];
 
-  areaPath.push(['L', width, 0]);
-  areaPath.push(['L', 0, height]);
+  const lineYPx = getAreaLineY(data, height);
+
+  areaPath.push(['L', width, lineYPx]);
+  areaPath.push(['L', 0, lineYPx]);
   areaPath.push(['Z']);
 
   return areaPath;

--- a/src/trend/trend.ts
+++ b/src/trend/trend.ts
@@ -69,7 +69,7 @@ export class Trend extends GroupComponent<TrendCfg> {
     // area
     // 在 path 的基础上，增加两个坐标点
     if (isArea) {
-      const areaPath = linePathToAreaPath(path, width, height);
+      const areaPath = linePathToAreaPath(path, width, height, data);
       this.addShape(group, {
         id: this.getElementId('area'),
         type: 'path',

--- a/tests/unit/trend/path-spec.ts
+++ b/tests/unit/trend/path-spec.ts
@@ -1,0 +1,9 @@
+import { getAreaLineY } from '../../../src/trend/path';
+
+describe('trend path', () => {
+  it('getAreaLineY', () => {
+    expect(getAreaLineY([1, 2, 3, 4, 5], 50)).toBe(50);
+
+    expect(getAreaLineY([-1, -2, -3, 4, 5, ], 50)).toBe(31.25);
+  });
+});


### PR DESCRIPTION
 - [x] 趋势图，面积模式，最后的连线计算不对
 - [x] 添加单测

| before  | after  |
|---|:-:|
| ![image](https://user-images.githubusercontent.com/7856674/90865271-b6e86480-e3c4-11ea-8422-2f083ac1b81d.png)  | ![image](https://user-images.githubusercontent.com/7856674/90865278-ba7beb80-e3c4-11ea-8fc8-e64351d3307e.png)  |



