### PR TITLE
fix(axis): when line, label all is null

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/component",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "The component module for antv",
   "author": "https://github.com/orgs/antvis/people",
   "license": "MIT",

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -70,6 +70,9 @@ export function pointsToBBox(points: Point[]): BBox {
 }
 
 export function createBBox(x: number, y: number, width: number, height: number): BBox {
+  const maxX = x + width;
+  const maxY = y + height;
+  
   return {
     x,
     y,
@@ -77,8 +80,12 @@ export function createBBox(x: number, y: number, width: number, height: number):
     height,
     minX: x,
     minY: y,
-    maxX: x + width,
-    maxY: y + height,
+    // 非常奇葩的 js 特性
+    // Infinity + Infinity = Infinity
+    // Infinity - Infinity = NaN
+    // fixed https://github.com/antvis/G2Plot/issues/1243
+    maxX: isNaN(maxX) ? 0 : maxX,
+    maxY: isNaN(maxY) ? 0 : maxY,
   };
 }
 

--- a/tests/unit/axis/empty-line-spec.ts
+++ b/tests/unit/axis/empty-line-spec.ts
@@ -1,0 +1,40 @@
+import { Canvas } from '@antv/g-canvas';
+import LineAxis from '../../../src/axis/line';
+
+describe('line axis empty', () => {
+  const dom = document.createElement('div');
+  document.body.appendChild(dom);
+  dom.id = 'cal';
+  const canvas = new Canvas({
+    container: 'cal',
+    width: 500,
+    height: 500,
+  });
+  const container = canvas.addGroup();
+  const axis = new LineAxis({
+    animate: false,
+    id: 'a',
+    container,
+    updateAutoRender: true,
+    start: { x: 50, y: 50 },
+    end: { x: 400, y: 50 },
+    ticks: [
+      { name: '1', value: 0 },
+      { name: '2', value: 0.5 },
+      { name: '3', value: 1 },
+    ],
+    label: null,
+    line: null,
+  });
+
+  axis.init();
+  axis.render();
+
+  it('getBBox, getLayoutBBox', () => {
+    expect(axis.getBBox().width).toBe(0);
+    expect(axis.getBBox().height).toBe(0);
+
+    expect(axis.getLayoutBBox().width).toBe(350);
+    expect(axis.getLayoutBBox().height).toBe(0);
+  });
+});


### PR DESCRIPTION
fixed https://github.com/antvis/G2Plot/issues/1243

当 axis 中 line label 等都为空的时候，会导致 getLayoutBBox 返回为 NaN，从而导致上层布局挂掉。