### PR TITLE
fix(axis): label  style 回调的参数应该是调整完后的值

### DIFF
--- a/tests/bugs/issue-axis-style-callback.ts
+++ b/tests/bugs/issue-axis-style-callback.ts
@@ -15,12 +15,15 @@ describe('axis title spacing', () => {
     id: 'a',
     container: canvas.addGroup(),
     updateAutoRender: true,
-    start: { x: 50, y: 400 },
+    start: { x: 50, y: 100 },
     end: { x: 50, y: 50 },
     ticks: [
       { name: '1', value: 0 },
-      { name: '2', value: 0.5 },
-      { name: '3', value: 1 },
+      { name: '2', value: 0.2 },
+      { name: '3', value: 0.4 },
+      { name: '4', value: 0.6 },
+      { name: '5', value: 0.8 },
+      { name: '6', value: 1 },
     ],
     title: {
       text: '标题',
@@ -33,9 +36,16 @@ describe('axis title spacing', () => {
       }
     },
     label: {
-      style: (val) => {
+      style: (val, index) => {
         return {
-          text: val + '@'
+          text: index % 2 !== 0 ? val + '@' : val,
+        }
+      }
+    },
+    tickLine: {
+      style: (item, index) => {
+        return {
+          stroke: index % 2 !== 0 ? 'red' : '#000',
         }
       }
     }
@@ -45,7 +55,49 @@ describe('axis title spacing', () => {
 
   it('render', () => {
     const labelShapes = axis.getElementsByName('axis-label');
-    expect(labelShapes[0].attr('fill')).toBe('red');
-    expect(labelShapes[0].attr('text')).toBe('1@');
+    expect(labelShapes.length).toBe(6);
+
+    const label2 = labelShapes.find(shape => shape.get('id') === 'a-axis-label-2')
+    const label3 = labelShapes.find(shape => shape.get('id') === 'a-axis-label-3')
+    expect(label2.attr('fill')).toBe('red');
+    expect(label2.attr('text')).toBe('2@');
+    expect(label3.attr('fill')).toBe('red');
+    expect(label3.attr('text')).toBe('3');
+
+    // const tickLineShapes = axis.getElementsByName('axis-tickLine');
+    // expect(tickLineShapes.length).toBe(6);
+    // const tickLine2 = tickLineShapes.find(shape => shape.get('id') === 'a-axis-tickline-2')
+    // const tickLine3 = tickLineShapes.find(shape => shape.get('id') === 'a-axis-tickline-3')
+    // expect(tickLine2.attr('stroke')).toBe('red');
+    // expect(tickLine3.attr('stroke')).toBe('#000');
+  });
+
+  it('processOverlap', () => {
+    axis.update({
+      label: {
+        autoHide: true,
+        style: (val, index) => {
+          return {
+            text: index % 2 !== 0 ? val + '@' : val,
+          }
+        }
+      }
+    });
+
+    const labelShapes = axis.getElementsByName('axis-label');
+    expect(labelShapes.length).toBe(3);
+
+    const label2 = labelShapes.find(shape => shape.get('id') === 'a-axis-label-2')
+    const label3 = labelShapes.find(shape => shape.get('id') === 'a-axis-label-3')
+    expect(label2).toBeUndefined();
+    expect(label3.attr('fill')).toBe('red');
+    expect(label3.attr('text')).toBe('3@');
+
+    // const tickLineShapes = axis.getElementsByName('axis-tickLine');
+    // expect(tickLineShapes.length).toBe(3);
+    // const tickLine2 = tickLineShapes.find(shape => shape.get('id') === 'a-axis-tickline-2')
+    // const tickLine3 = tickLineShapes.find(shape => shape.get('id') === 'a-axis-tickline-3')
+    // expect(tickLine2).toBeUndefined();
+    // expect(tickLine3.attr('stroke')).toBe('red');
   });
 });


### PR DESCRIPTION
原先的 style 返回的是所有的 ticks，这样就导致如果坐标轴文本自动隐藏的时候，index 对应的一些文本被隐藏，设置不生效。

style 回调提供的参数应该是最后显示在图表上的 items。而不是原先全量的 items.

这里先处理下 label，解决业务迫切问题，tickLine 也要处理下，这个后面提交 PR