### PR TITLE
fix: 修复 axis title offset

### DIFF
--- a/src/axis/overlap/auto-rotate.ts
+++ b/src/axis/overlap/auto-rotate.ts
@@ -1,5 +1,5 @@
 import { IElement, IGroup } from '@antv/g-base';
-import { each } from '@antv/util';
+import { each, isNumber } from '@antv/util';
 import { getMaxLabelWidth } from '../../util/label';
 import { getMatrixByAngle } from '../../util/matrix';
 import Theme from '../../util/theme';
@@ -59,10 +59,19 @@ export function getDefault() {
  * @param  {boolean} isVertical  是否垂直方向
  * @param  {IGroup}  labelsGroup 文本的 group
  * @param  {number}  limitLength 限定长度
+ * @param  {number}  customRotate 自定义旋转角度
  * @return {boolean}             是否发生了旋转
  */
-export function fixedAngle(isVertical: boolean, labelsGroup: IGroup, limitLength: number): boolean {
+export function fixedAngle(
+  isVertical: boolean,
+  labelsGroup: IGroup,
+  limitLength: number,
+  customRotate?: number
+): boolean {
   return labelRotate(isVertical, labelsGroup, limitLength, () => {
+    if (isNumber(customRotate)) {
+      return customRotate;
+    }
     return isVertical ? Theme.verticalAxisRotate : Theme.horizontalAxisRotate;
   });
 }

--- a/tests/unit/axis/auto-title-spec.ts
+++ b/tests/unit/axis/auto-title-spec.ts
@@ -1,0 +1,146 @@
+import { Canvas } from '@antv/g-canvas';
+import LineAxis from '../../../src/axis/line';
+
+describe('test title offset', () => {
+  const labelsArray = ['不知名学科名字很长很长真的很长', '语文', '数学', '英语', '物理'];
+  function getTicks(labels: string[]) {
+    const items = [];
+    const length = labels.length;
+    labels.forEach((label, index) => {
+      const value = index / (length - 1);
+      items.push({ name: label, id: index.toString(), value });
+    });
+    return items;
+  }
+
+  const dom = document.createElement('div');
+  document.body.appendChild(dom);
+  dom.id = 'offset';
+  const canvas = new Canvas({
+    container: 'offset',
+    width: 500,
+    height: 500,
+  });
+  const position = {
+    top: {
+      start: { x: 200, y: 200 },
+      end: { x: 300, y: 200 },
+    },
+    right: {
+      start: { x: 200, y: 200 },
+      end: { x: 200, y: 300 },
+    },
+    left: {
+      start: { x: 200, y: 300 },
+      end: { x: 200, y: 200 },
+    },
+  };
+  const ticks = getTicks(labelsArray);
+  const container = canvas.addGroup();
+  const axis = new LineAxis({
+    animate: false,
+    id: 'l',
+    container,
+    updateAutoRender: true,
+    ...position.top,
+    ticks,
+    title: {
+      text: '标题也很长很长合成词错错',
+    },
+  });
+  axis.init();
+  axis.render();
+
+  it('test render', () => {
+    const bbox = axis.getBBox();
+    expect(bbox).toEqual(axis.getLayoutBBox());
+    const title = axis.getElementById('l-axis-title');
+    expect(title.attr('matrix')).not.toBe(null);
+    expect(axis.get('title').offset).not.toBeUndefined();
+    expect(axis.get('title').text).toBe('标题也很长很长合成词错错');
+  });
+
+  // title offset 依赖 label rotate
+  it('update', () => {
+    axis.update({
+      ...position.left,
+      title: {
+        text: '标题也很长很长',
+      },
+      label: {
+        rotate: Math.PI / 3,
+        style: {
+          fill: 'red',
+        },
+      },
+    });
+    expect(axis.get('title').text).toBe('标题也很长很长');
+    expect(axis.get('label').rotate).toBe(Math.PI / 3);
+    expect(axis.get('label').style.fill).toBe('red');
+    const bbox = axis.getBBox();
+    const length = axis.get('title').offset - bbox.width;
+    axis.update({
+      ...position.left,
+      title: {
+        text: '标题也很长很长',
+      },
+      label: {
+        rotate: Math.PI / 6,
+        style: {
+          fill: 'red',
+        },
+      },
+    });
+    const currentLength = axis.get('title').offset - axis.getBBox().width;
+    expect(axis.get('label').rotate).toBe(Math.PI / 6);
+    // label rotate 会影响 axis bbox
+    expect(bbox.width).not.toBe(axis.getBBox().width);
+    // floor 去除计算溢出问题
+    expect(Math.floor(currentLength) - Math.floor(length)).toBe(0);
+
+    axis.update({
+      ...position.right,
+      title: {
+        text: '标题也很长很长',
+      },
+      label: {
+        style: {
+          fill: 'red',
+        },
+      },
+    });
+    // 直接返回 groupBbox.width
+    expect(axis.get('title').offset).toBe(201);
+    const offset = axis.get('title').offset;
+    axis.update({
+      ...position.right,
+      title: {
+        text: '标题也很长很长',
+      },
+      label: {
+        rotate: Math.PI / 3,
+        style: {
+          fill: 'red',
+        },
+      },
+    });
+    expect(Math.round(offset - axis.get('title').offset)).toBe(90);
+    axis.update({
+      ...position.top,
+      title: {
+        text: '标题也很长很长',
+      },
+      label: {
+        rotate: Math.PI / 6,
+        style: {
+          fill: 'red',
+        },
+      },
+    });
+    expect(Math.round(offset - axis.get('title').offset)).toBe(90);
+  });
+  afterAll(() => {
+    axis.destroy();
+    canvas.destroy();
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
修复标题重叠问题 https://github.com/antvis/G2Plot/issues/1820

现有代码在设置 title offset 时没有考虑 label rotated 的情况， 直接使用了 bbox 的 width 或 height ， 在用户设置了 label rotate 或者触发 autoRotate 时需要重新计算 bbox ， 加上 rotate 产生的 maxLength。