### PR TITLE
feat:  添加 itemName style 回调

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -769,7 +769,7 @@ export interface LegendItemNameCfg {
    * 文本配置项
    * @type {ShapeAttrs}
    */
-  style?: ShapeAttrs;
+  style?: ShapeAttrs | ShapeAttrsCallback;
 }
 
 type formatterCallback = (text: string, item: ListItem, index: number) => any;
@@ -789,7 +789,7 @@ export interface LegendItemValueCfg {
    * 图例项附加值的配置
    * @type {ShapeAttrs}
    */
-  style?: ShapeAttrs;
+  style?: ShapeAttrs  | ShapeAttrsCallback;
 }
 
 export interface LegendMarkerCfg {

--- a/tests/unit/legend/category-spec.ts
+++ b/tests/unit/legend/category-spec.ts
@@ -1176,6 +1176,37 @@ describe('test category legend', () => {
       })
     })
 
+    it('item has itemName styleCallBack config', () => {
+      const itemName = {
+        style: (item, index, items) => {
+          return {
+            fill: item.marker.style.fill,
+            fontSize: index ? 20 : 30,
+          }
+        }
+      }
+      const newItem = [
+        { name: 'a', value: 1, marker: { spacing: 10, symbol: 'circle', style: { r: 4, fill: 'red' } } },
+        { name: 'b', value: 2, marker: { spacing: 20, symbol: 'square', style: { r: 5, fill: 'red' } } },
+        { name: 'c', value: 3, marker: { spacing: 30, symbol: 'triangle', style: { r: 6, fill: 'blue' } } },
+        { name: 'd', value: 4, marker: { spacing: 40, symbol: 'line', style: { r: 6, fill: 'blue' } } },
+      ];
+
+      legend.update({
+        itemName,
+        items: newItem,
+      });
+
+      newItem.forEach((item, index) => {
+        const itemGroup = legend.getElementById(`c-legend-item-${item.name}`)
+        const textElement = itemGroup.getChildren()[1];
+
+        expect(textElement.attrs.fill).toBe(newItem[index].marker.style.fill);
+        expect(textElement.attrs.fontSize).toBe(index ? 20 : 30);
+        expect(itemGroup.getCanvasBBox().height).toBe(index ? 20 : 30);
+      });
+    })
+
     it('destroy', () => {
       legend.destroy();
       expect(legend.destroyed).toBe(true);


### PR DESCRIPTION
- [x]   feat(legend):  添加 legend 的 itemName 和 itemValue 的 style 回调 

![image](https://user-images.githubusercontent.com/65594180/125562205-c0f996c9-ec2d-47ff-8883-371af18a6f09.png)


通过 对  绘制文本方法 进行 style 的 适配。达到回调的实现。
![image](https://user-images.githubusercontent.com/65594180/125562366-9df50938-c580-497e-baa1-96b40359c258.png)


