### PR TITLE
Fix legend values

### DIFF
--- a/src/legend/continuous.ts
+++ b/src/legend/continuous.ts
@@ -478,10 +478,14 @@ class ContinueLegend extends LegendBase<ContinueLegendCfg> implements ISlider {
 
   // 当前选中的范围
   private getCurrentValue(): number[] {
-    let value = this.get('value');
+    const value = this.get('value');
     if (!value) {
-      // 如果没有定义，取最大范围
-      value = [this.get('min'), this.get('max')];
+      const values = this.get('values');
+      if (!values) {
+        return [this.get('min'), this.get('max')];
+      }
+      // 如果没有定义，取最大范围  最小值 为 values 中的最小值， 如果最小值 超过了 定义的最大值 则 做限制  最大值 反之
+      return [Math.max(Math.min(...values, this.get('max')), this.get('min')), Math.min(Math.max(...values, this.get('min')), this.get('max'))];
     }
     return value;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -769,7 +769,7 @@ export interface LegendItemNameCfg {
    * 文本配置项
    * @type {ShapeAttrs}
    */
-  style?: ShapeAttrs;
+  style?: ShapeAttrs | ShapeAttrsCallback;
 }
 
 type formatterCallback = (text: string, item: ListItem, index: number) => any;
@@ -789,7 +789,7 @@ export interface LegendItemValueCfg {
    * 图例项附加值的配置
    * @type {ShapeAttrs}
    */
-  style?: ShapeAttrs;
+  style?: ShapeAttrs  | ShapeAttrsCallback;
 }
 
 export interface LegendMarkerCfg {

--- a/tests/unit/legend/category-spec.ts
+++ b/tests/unit/legend/category-spec.ts
@@ -1176,6 +1176,37 @@ describe('test category legend', () => {
       })
     })
 
+    it('item has itemName styleCallBack config', () => {
+      const itemName = {
+        style: (item, index, items) => {
+          return {
+            fill: item.marker.style.fill,
+            fontSize: index ? 20 : 30,
+          }
+        }
+      }
+      const newItem = [
+        { name: 'a', value: 1, marker: { spacing: 10, symbol: 'circle', style: { r: 4, fill: 'red' } } },
+        { name: 'b', value: 2, marker: { spacing: 20, symbol: 'square', style: { r: 5, fill: 'red' } } },
+        { name: 'c', value: 3, marker: { spacing: 30, symbol: 'triangle', style: { r: 6, fill: 'blue' } } },
+        { name: 'd', value: 4, marker: { spacing: 40, symbol: 'line', style: { r: 6, fill: 'blue' } } },
+      ];
+
+      legend.update({
+        itemName,
+        items: newItem,
+      });
+
+      newItem.forEach((item, index) => {
+        const itemGroup = legend.getElementById(`c-legend-item-${item.name}`)
+        const textElement = itemGroup.getChildren()[1];
+
+        expect(textElement.attrs.fill).toBe(newItem[index].marker.style.fill);
+        expect(textElement.attrs.fontSize).toBe(index ? 20 : 30);
+        expect(itemGroup.getCanvasBBox().height).toBe(index ? 20 : 30);
+      });
+    })
+
     it('destroy', () => {
       legend.destroy();
       expect(legend.destroyed).toBe(true);

--- a/tests/unit/legend/category-spec.ts
+++ b/tests/unit/legend/category-spec.ts
@@ -360,13 +360,13 @@ describe('test category legend', () => {
         maxItemWidth: 80,
       });
       const item1 = legend.getElementById('c-legend-item-测试测试测试测试测试 1');
-      expect(item1.getBBox().width).toBeCloseTo(40);
+      expect(item1.getBBox().width).toBeLessThan(40);
       const item1Name = legend.getElementById('c-legend-item-测试测试测试测试测试 1-name');
       expect(item1Name.attr('text').indexOf('…')).toBeGreaterThan(-1);
       expect(item1Name.get('tip')).toBe('测试测试测试测试测试 1');
 
       const item2 = legend.getElementById('c-legend-item-测试 2');
-      expect(item2.getBBox().width).toBeCloseTo(40);
+      expect(item2.getBBox().width).toBeLessThan(40);
       const item2Name = legend.getElementById('c-legend-item-测试 2-name');
       expect(item2Name.attr('text').indexOf('…')).toBeGreaterThan(-1);
       expect(item2Name.get('tip')).toBe('测试 2');
@@ -378,13 +378,13 @@ describe('test category legend', () => {
         itemWidth: 80,
       });
       const item1 = legend.getElementById('c-legend-item-测试测试测试测试测试 1');
-      expect(item1.getBBox().width).toBeCloseTo(40);
+      expect(item1.getBBox().width).toBeLessThan(40);
       const item1Name = legend.getElementById('c-legend-item-测试测试测试测试测试 1-name');
       expect(item1Name.attr('text').indexOf('…')).toBeGreaterThan(-1);
       expect(item1Name.get('tip')).toBe('测试测试测试测试测试 1');
 
       const item2 = legend.getElementById('c-legend-item-测试 2');
-      expect(item2.getBBox().width).toBeCloseTo(40);
+      expect(item2.getBBox().width).toBeLessThan(40);
       const item2Name = legend.getElementById('c-legend-item-测试 2-name');
       expect(item2Name.attr('text').indexOf('…')).toBeGreaterThan(-1);
       expect(item2Name.get('tip')).toBe('测试 2');

--- a/tests/unit/legend/continuous-spec.ts
+++ b/tests/unit/legend/continuous-spec.ts
@@ -673,4 +673,33 @@ describe('test continue legend', () => {
       expect(legend.getValue()).toEqual([500, 1000]);
     });
   });
+
+  describe('test continuous values', () => {
+    const container = canvas.addGroup();
+    const legend = new ContinuousLegend({
+      id: 'e',
+      container,
+      x: 300,
+      y: 300,
+      min: 100,
+      max: 1000,
+      values: [200, 800]
+    });
+    legend.init();
+    it('change values', () => {
+      expect(legend.getValue()).toEqual([200, 800]);
+
+      legend.update({ values: [0, 2000] });
+      expect(legend.getValue()).toEqual([100, 1000]);
+
+      legend.update({ values: [500] });
+      expect(legend.getValue()).toEqual([500, 500]);
+
+      legend.update({ values: [0] });
+      expect(legend.getValue()).toEqual([100, 100]);
+
+      legend.update({ values: [] });
+      expect(legend.getValue()).toEqual([1000, 100]);
+    });
+  });
 });


### PR DESCRIPTION

- [x]  修改连续图例 中的 values 暴露出去。 values 为默认值，不影响后续的交互

- [x]  修改 test 中的测试  itemWidh  的设置，相当于 item 单个的 maxItemWidth 设置。 使用toBeCloseTo 并不合理 现在写成 toBeLessThan