### PR TITLE
fix:  【legend】 期望分页场景下的多行和不分页的多行，展示一致

### DIFF
--- a/src/legend/category.ts
+++ b/src/legend/category.ts
@@ -501,9 +501,11 @@ class Category extends LegendBase<CategoryLegendCfg> implements IList {
     let widthLimit = 0;
     let pageWidth = 0;
     let maxItemWidth = 0;
-
+    const itemMarginBottom = this.get('itemMarginBottom');
     if (layout === 'horizontal') {
-      this.pageHeight = itemHeight * (this.get('maxRow') || 1);
+      const maxRow = this.get('maxRow') || 1;
+      const maxRowHeight = itemHeight + (maxRow === 1 ? 0 : itemMarginBottom);
+      this.pageHeight = maxRowHeight * maxRow;
       each(subGroups, (item) => {
         const bbox = item.getBBox();
         const width = itemWidth || bbox.width;
@@ -521,7 +523,7 @@ class Category extends LegendBase<CategoryLegendCfg> implements IList {
           }
           pages += 1;
           currentPoint.x = startX;
-          currentPoint.y += itemHeight;
+          currentPoint.y += maxRowHeight;
         }
         this.moveElementTo(item, currentPoint);
         item.getParent().setClip({
@@ -536,7 +538,6 @@ class Category extends LegendBase<CategoryLegendCfg> implements IList {
         currentPoint.x += width + itemSpacing;
       });
     } else {
-      const itemMarginBottom = this.get('itemMarginBottom');
       each(subGroups, (item) => {
         const bbox = item.getBBox();
         if (bbox.width > pageWidth) {

--- a/tests/unit/legend/category-flippage-spec.ts
+++ b/tests/unit/legend/category-flippage-spec.ts
@@ -82,13 +82,13 @@ describe('test category legend', () => {
 
       legend.update({ maxRow: 2 });
       itemGroup = legend.getElementById('c-legend-item-group');
-      expect(itemGroup.getParent().getClip().getBBox().height).toBe(24)
+      expect(itemGroup.getParent().getClip().getBBox().height).toBe(40)
     });
 
     it('maxRow', () => {
       legend.update({ maxRow: 3 });
       const itemGroup = legend.getElementById('c-legend-item-group');
-      expect(itemGroup.getParent().getClip().getBBox().height).toBe(36)
+      expect(itemGroup.getParent().getClip().getBBox().height).toBe(60)
     });
 
     afterAll(() => {


### PR DESCRIPTION
- [x]   在 多行分页下  上下间距 和 不分页一致。
![image](https://user-images.githubusercontent.com/65594180/127457804-dd17cd4d-18e8-4799-9607-7eb4fc8e1c79.png)
