### PR TITLE
fix(component): set default value for defaultCfg

### DIFF
--- a/src/abstract/component.ts
+++ b/src/abstract/component.ts
@@ -65,7 +65,7 @@ abstract class Component<T extends ComponentCfg = ComponentCfg> extends Base imp
    * @param {object} cfg 更新属性
    */
   public update(cfg: Partial<T>) {
-    const defaultCfg = this.get('defaultCfg');
+    const defaultCfg = this.get('defaultCfg') || {};
     each(cfg, (value, name) => {
       const originCfg = this.get(name);
       let newCfg = value;


### PR DESCRIPTION
在Chart还未渲染出来前，将鼠标移动Chart上，并快速移动，会出现如下错误
```
component.js:75 Uncaught TypeError: Cannot read property 'marker' of undefined
    at component.js:75
    at each (each.js:19)
    at Tooltip.push../node_modules/@antv/component/esm/abstract/component.js.Component.update (component.js:70)
    at Tooltip.push../node_modules/@antv/g2/esm/chart/controller/tooltip.js.Tooltip.showTooltip (tooltip.js:87)
    at Chart.push../node_modules/@antv/g2/esm/chart/view.js.View.showTooltip (view.js:856)
    at TooltipAction.push../node_modules/@antv/g2/esm/interaction/action/component/tooltip/geometry.js.TooltipAction.showTooltip (geometry.js:63)
    at TooltipAction.push../node_modules/@antv/g2/esm/interaction/action/component/tooltip/geometry.js.TooltipAction.show (geometry.js:36)
    at executeAction (grammar-interaction.js:26)
    at Chart.actionCallback (grammar-interaction.js:225)
    at Chart.throttled (throttle.js:26)
```

尝试在`@antv/component/esm/abstract/component.js.Component.update`上打印`defaultCfg`，发现会在得到一次`undefined`，从而引发上面的错误。
![image](https://user-images.githubusercontent.com/7121951/136948192-20fd4dc2-3482-4d80-b14b-60c06c7ce754.png)

![image](https://user-images.githubusercontent.com/7121951/136948154-1bdc1942-a9d3-4f88-bb22-c71e2aacfc85.png)

此PR，给`defaultCfg`添加一个默认值`{}`