### PR TITLE
fix: safari15 对-apple-system 字体支持有问题导致页面卡死

### DIFF
--- a/src/util/theme.ts
+++ b/src/util/theme.ts
@@ -1,6 +1,6 @@
 export default {
   fontFamily: `
-  "-apple-system", BlinkMacSystemFont, "Segoe UI", Roboto,"Helvetica Neue",
+  BlinkMacSystemFont, "Segoe UI", Roboto,"Helvetica Neue",
   Helvetica, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei",
   SimSun, "sans-serif"`,
   textColor: '#2C3542',


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
follow this fix 👍 https://github.com/antvis/G2/pull/3640/files

<!-- Provide a description of the change below this comment. -->
