### PR TITLE
fix(tooltip): 自定义tooltip内容时transition未生效

### DIFF
--- a/src/abstract/html-component.ts
+++ b/src/abstract/html-component.ts
@@ -98,8 +98,14 @@ abstract class HtmlComponent<T extends ComponentCfg = HtmlComponentCfg> extends 
   protected initContainer() {
     let container = this.get('container');
     if (isNil(container)) {
-      // 未指定 container 则创建
-      container = this.createDom();
+      if (this.get('customContent')) {
+        // 在生成container的时候, 如果是自定义内容的tooltip, 则生成一个恒定的容器, 用于定位
+        container = document.createElement('div');
+        container.className = 'g2-tooltip-position';
+      } else {
+        // 未指定 container 则创建
+        container = this.createDom();
+      }
       let parent = this.get('parent');
       if (isString(parent)) {
         parent = document.getElementById(parent);

--- a/src/tooltip/html.ts
+++ b/src/tooltip/html.ts
@@ -135,12 +135,10 @@ class Tooltip<T extends TooltipCfg = TooltipCfg> extends HtmlComponent implement
   protected initContainer() {
     super.initContainer();
     if (this.get('customContent')) {
-      if (this.get('container')) {
-        this.get('container').remove();
-      }
-      const container = this.getHtmlContentNode();
-      this.get('parent').appendChild(container);
-      this.set('container', container);
+      const node = this.getHtmlContentNode();
+      const container: HTMLElement = this.get('container');
+      container.innerHTML = '';
+      container.appendChild(node);
       this.resetStyles();
       this.applyStyles();
     }
@@ -198,14 +196,9 @@ class Tooltip<T extends TooltipCfg = TooltipCfg> extends HtmlComponent implement
   // 根据 customContent 渲染
   private renderCustomContent() {
     const node = this.getHtmlContentNode();
-    const parent: HTMLElement = this.get('parent');
-    const curContainer: HTMLElement = this.get('container');
-    if (curContainer && curContainer.parentNode === parent) {
-      parent.replaceChild(node, curContainer);
-    } else {
-      parent.appendChild(node);
-    }
-    this.set('container', node);
+    const container: HTMLElement = this.get('container');
+    container.innerHTML = '';
+    container.appendChild(node);
     this.resetStyles();
     this.applyStyles();
   }

--- a/tests/unit/tooltip/html-spec.ts
+++ b/tests/unit/tooltip/html-spec.ts
@@ -313,11 +313,13 @@ describe('test tooltip', () => {
     it('init', () => {
       tooltip.init();
       container = tooltip.getContainer();
-      expect(Array.from(container.classList).includes('g2-tooltip')).toBe(true);
-      expect(Array.from(container.classList).includes('custom-html-tooltip')).toBe(true);
+      const firstChild = container.firstElementChild as HTMLElement;
+      expect(Array.from(container.classList).includes('g2-tooltip-position')).toBe(true);
+      expect(Array.from(firstChild.classList).includes('g2-tooltip')).toBe(true);
+      expect(Array.from(firstChild.classList).includes('custom-html-tooltip')).toBe(true);
       each(HtmlTheme[CssConst.CONTAINER_CLASS], (val, key) => {
         if (!['transition', 'boxShadow', 'fontFamily', 'padding'].includes(key)) {
-          expect(container.style[key] + '').toBe(val + '');
+          expect(firstChild.style[key] + '').toBe(val + '');
         }
       });
     });
@@ -325,22 +327,24 @@ describe('test tooltip', () => {
     it('render', () => {
       tooltip.render();
       container = tooltip.getContainer();
-      expect(Array.from(container.classList).includes('g2-tooltip')).toBe(true);
-      expect(Array.from(container.classList).includes('custom-html-tooltip')).toBe(true);
-      const title = container.getElementsByClassName('g2-tooltip-title')[0] as HTMLElement;
+      const firstChild = container.firstElementChild as HTMLElement;
+      expect(Array.from(container.classList).includes('g2-tooltip-position')).toBe(true);
+      expect(Array.from(firstChild.classList).includes('g2-tooltip')).toBe(true);
+      expect(Array.from(firstChild.classList).includes('custom-html-tooltip')).toBe(true);
+      const title = firstChild.getElementsByClassName('g2-tooltip-title')[0] as HTMLElement;
       expect(title.innerText).toBe('My Title html');
-      const listItems = Array.from(container.getElementsByClassName('g2-tooltip-list-item')) as HTMLElement[];
+      const listItems = Array.from(firstChild.getElementsByClassName('g2-tooltip-list-item')) as HTMLElement[];
       each(listItems, (listItem, index) => {
         expect(Array.from(listItem.classList).includes('my-list-item')).toBe(true);
         expect(listItem.innerText).toBe(`My Value: ${items[index].value}`);
       });
       each(HtmlTheme[CssConst.CONTAINER_CLASS], (val, key) => {
         if (!['transition', 'boxShadow', 'fontFamily', 'padding'].includes(key)) {
-          expect(container.style[key] + '').toBe(val + '');
+          expect(firstChild.style[key] + '').toBe(val + '');
         }
       });
       each(HtmlTheme, (val, key) => {
-        const elements = container.getElementsByClassName(key);
+        const elements = firstChild.getElementsByClassName(key);
         each(elements, (element) => {
           each(val, (cssVal, cssKey) => {
             if (!['transition', 'boxShadow', 'fontFamily', 'padding'].includes(cssKey)) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->

`tooltip`为`customContent`时, transition未生效. 详情可以看下面这张gif
[https://file.qingflow.com/uploads/file/ce8f0f29-15f0-4439-a980-4b58ec20f3b8.gif](https://file.qingflow.com/uploads/file/ce8f0f29-15f0-4439-a980-4b58ec20f3b8.gif)

改动稍微有一点大, 已经通过所有单测. 官方可以再详细测下, 我会在代码内容区写上相关评论以帮助你们更好理解此次PR的逻辑.
![图片](https://user-images.githubusercontent.com/30228406/146395411-c8ef2e95-d7b8-4244-b0ac-379d7e02be9e.png)

在修改之后, 在有`customContent`的场景下, DOM会是如下结构. `g2-tooltip-position`仅仅用来作定位使用.
![图片](https://user-images.githubusercontent.com/30228406/146397016-d2f6d852-ac66-48b3-ba7f-705c386c99ff.png)

另外, 因为component没有独立的网站, 我是通过jest-electron进行测试的, 这种改法是否真的会生效我并不确定, 我只是按照理论进行修改. 需要官方团队再次验证.