### PR TITLE
feat(legend): 添加正反选按钮

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/component",
-  "version": "0.8.20",
+  "version": "0.8.21",
   "description": "The component module for antv",
   "author": "https://github.com/orgs/antvis/people",
   "license": "MIT",

--- a/src/types.ts
+++ b/src/types.ts
@@ -269,7 +269,7 @@ export interface AxisTitleCfg {
    * 文本对齐方式
    * @type {string} start, center, end
    */
-   position?: string;
+  position?: string;
 }
 
 export interface BaseCfg {
@@ -594,6 +594,11 @@ export interface CategoryLegendCfg extends LegendBaseCfg {
    */
   itemValue?: LegendItemValueCfg;
   /**
+   *
+   * @type {LegendRadio}
+   */
+  radio?: LegendRadio;
+  /**
    * 最大宽度
    * @type {number}
    */
@@ -616,11 +621,11 @@ export interface CategoryLegendCfg extends LegendBaseCfg {
   /**
    * 是否翻页
    */
-   flipPage?: boolean;
-   /**
-    * 翻页行数（只适用于横向） 
-    */
-   maxRow?: number;
+  flipPage?: boolean;
+  /**
+   * 翻页行数（只适用于横向）
+   */
+  maxRow?: number;
   /**
    * 分页器配置
    * @type {LegendPageNavigatorCfg}
@@ -807,7 +812,20 @@ export interface LegendItemValueCfg {
    * 图例项附加值的配置
    * @type {ShapeAttrs}
    */
-  style?: ShapeAttrs  | ShapeAttrsCallback;
+  style?: ShapeAttrs | ShapeAttrsCallback;
+  /**
+   * 图例值和后面的间隔，可以控制和 RadioIcon 的间距
+   * @type {number}
+   */
+  spacing?: number;
+}
+
+export interface LegendRadio {
+  /**
+   * radio 的配置项
+   * @type {ShapeAttrs}
+   */
+  style?: ShapeAttrs;
 }
 
 export interface LegendMarkerCfg {

--- a/tests/unit/legend/category-radio-spec.ts
+++ b/tests/unit/legend/category-radio-spec.ts
@@ -1,0 +1,124 @@
+import { Canvas } from '@antv/g-canvas';
+import CategoryLegend from '../../../src/legend/category';
+
+function createMountedDiv() {
+  const div = document.createElement('div');
+  document.body.appendChild(div);
+  return div;
+}
+
+function renderLegend(options = {}) {
+  const canvas = new Canvas({
+    width: 500,
+    height: 200,
+    container: createMountedDiv(),
+  });
+
+  const container = canvas.addGroup();
+
+  const legend = new CategoryLegend({
+    id: 'c',
+    container,
+    x: 100,
+    y: 100,
+    updateAutoRender: true,
+    itemBackground: null,
+    ...options,
+  });
+
+  legend.init();
+  legend.render();
+
+  return legend;
+}
+
+describe('分类图例的正反选功能', () => {
+  test('radio === falsy 的时候不会渲染 radio', () => {
+    const legend = renderLegend({
+      items: [
+        { name: 'a', value: 123, marker: { symbol: 'square', style: { r: 4, fill: '#5B8FF9' } } },
+        { name: 'b', value: 223, marker: { symbol: 'square', style: { r: 4, fill: '#5AD8A6' } } },
+        { name: 'c', value: 323, marker: { symbol: 'square', style: { r: 4, fill: '#5D7092' } } },
+      ],
+    });
+
+    expect(legend.getElementsByName('legend-item-radio').length).toBe(0);
+  });
+
+  test('radio === truthy 会按照默认配置渲染 radio 并且只展示 show 为 true 的 item', () => {
+    const legend = renderLegend({
+      items: [
+        { name: 'a', value: 123, marker: { symbol: 'square', style: { r: 4, fill: '#5B8FF9' } } },
+        { name: 'b', value: 223, marker: { symbol: 'square', style: { r: 4, fill: '#5AD8A6' } }, showRadio: true },
+        { name: 'c', value: 323, marker: { symbol: 'square', style: { r: 4, fill: '#5D7092' } } },
+      ],
+      radio: {},
+    });
+
+    const radios = legend.getElementsByName('legend-item-radio');
+    const [hideRadio, showRadio] = radios;
+    expect(radios.length).toBe(3);
+    expect(hideRadio.attr('stroke')).toBe('#000000');
+    expect(hideRadio.attr('fill')).toBe('#ffffff');
+    expect(hideRadio.attr('opacity')).toBe(0);
+    expect(showRadio.attr('opacity')).toBe(0.45);
+  });
+
+  test('radio = {} 覆盖除了 opacity 之外的样式', () => {
+    const legend = renderLegend({
+      items: [
+        { name: 'a', value: 123, marker: { symbol: 'square', style: { r: 4, fill: '#5B8FF9' } } },
+        { name: 'b', value: 223, marker: { symbol: 'square', style: { r: 4, fill: '#5AD8A6' } }, showRadio: true },
+        { name: 'c', value: 323, marker: { symbol: 'square', style: { r: 4, fill: '#5D7092' } } },
+      ],
+      radio: {
+        opacity: 1,
+        fill: 'red',
+        stroke: 'blue',
+      },
+    });
+
+    const [radio] = legend.getElementsByName('legend-item-radio');
+    expect(radio.attr('stroke')).toBe('blue');
+    expect(radio.attr('fill')).toBe('red');
+    expect(radio.attr('opacity')).toBe(0);
+  });
+
+  test('radio 和 itemValue 的默认间距是 6', () => {
+    const legend = renderLegend({
+      items: [
+        { name: 'a', value: 123, marker: { symbol: 'square', style: { r: 4, fill: '#5B8FF9' } }, showRadio: true },
+        { name: 'b', value: 223, marker: { symbol: 'square', style: { r: 4, fill: '#5AD8A6' } } },
+        { name: 'c', value: 323, marker: { symbol: 'square', style: { r: 4, fill: '#5D7092' } } },
+      ],
+      radio: {},
+      itemValue: {},
+    });
+
+    const [radio] = legend.getElementsByName('legend-item-radio');
+    const [value] = legend.getElementsByName('legend-item-value');
+    const maxValueX = value.getBBox().maxX;
+    const minRadioX = radio.getBBox().x;
+    expect(minRadioX - maxValueX).toBe(4.792893218813447);
+  });
+
+  test('可以通过 itemValue.spacing 去配置 radio 和 itemValue 的间距', () => {
+    const legend = renderLegend({
+      items: [
+        { name: 'a', value: 123, marker: { symbol: 'square', style: { r: 4, fill: '#5B8FF9' } }, showRadio: true },
+        { name: 'b', value: 223, marker: { symbol: 'square', style: { r: 4, fill: '#5AD8A6' } } },
+        { name: 'c', value: 323, marker: { symbol: 'square', style: { r: 4, fill: '#5D7092' } } },
+      ],
+      radio: {},
+      itemValue: {
+        spacing: 10,
+      },
+    });
+
+    const [radio] = legend.getElementsByName('legend-item-radio');
+    const [value] = legend.getElementsByName('legend-item-value');
+    const maxValueX = value.getBBox().maxX;
+    const minRadioX = radio.getBBox().x;
+    expect(minRadioX - maxValueX).toBe(8.792893218813447);
+  });
+});


### PR DESCRIPTION

给图例增加正反选按钮，参考这个 [issue](https://github.com/antvis/G2/issues/3736)。

- [x] 单测

默认不开启，具体的功能参考下图。

```js
const legend = new CategoryLegend({
    id: 'c',
    container,
    x: 100,
    y: 100,
    updateAutoRender: true,
    itemBackground: null,
    items: [
        { name: 'a', value: 123, marker: { symbol: 'square', style: { r: 4, fill: '#5B8FF9' } } },
        // 只有 showRadio 为 true 才会显示出来，否者 opacity 为 0 只是一个占位符
        { name: 'b', value: 223, showRadio: true, marker: { symbol: 'square', style: { r: 4, fill: '#5AD8A6' } } },
        { name: 'c', value: 323, marker: { symbol: 'square', style: { r: 4, fill: '#5D7092' } } },
      ],
    // 开启并设置样式
    radio: {
      fill: 'red',
      stroke: 'blue'
    }
});
```
![image](https://user-images.githubusercontent.com/49330279/147482650-878ee4d3-170f-46a9-891f-39e26020eeb9.png)

