### PR TITLE
fix(annotation): 修复html 组件 html参数为 数字、空字符串 以及 特殊字符时出现的报错问题

### DIFF
--- a/src/annotation/html.ts
+++ b/src/annotation/html.ts
@@ -34,14 +34,10 @@ export default class HtmlAnnotation extends HtmlComponent<HtmlAnnotationCfg> imp
     if (isElement(rst)) {
       container.appendChild(rst as HTMLElement);
     } else if (isString(rst) || isNumber(rst)) {
-      let dom;
-      try {
-        dom = createDom(`${rst}` as string);
-      } catch (error) {
-        dom = createDom(`<div>${rst}</div>`);
+      const dom = createDom(`${rst}` as string);
+      if (dom) {
+        container.appendChild(dom);
       }
-
-      container.appendChild(dom);
     }
 
     this.resetPosition();

--- a/src/annotation/html.ts
+++ b/src/annotation/html.ts
@@ -1,5 +1,5 @@
 import { createDom, getOuterHeight, getOuterWidth, modifyCSS } from '@antv/dom-util';
-import { isElement, isFunction, isString } from '@antv/util';
+import { isElement, isFunction, isNumber, isString } from '@antv/util';
 import HtmlComponent from '../abstract/html-component';
 import { ILocation } from '../interfaces';
 import { HtmlAnnotationCfg, PointLocationCfg } from '../types';
@@ -33,8 +33,15 @@ export default class HtmlAnnotation extends HtmlComponent<HtmlAnnotationCfg> imp
 
     if (isElement(rst)) {
       container.appendChild(rst as HTMLElement);
-    } else if (isString(rst)) {
-      container.appendChild(createDom(rst as string));
+    } else if (isString(rst) || isNumber(rst)) {
+      let dom;
+      try {
+        dom = createDom(`${rst}` as string);
+      } catch (error) {
+        dom = createDom(`<div>${rst}</div>`);
+      }
+
+      container.appendChild(dom);
     }
 
     this.resetPosition();

--- a/src/types.ts
+++ b/src/types.ts
@@ -1042,7 +1042,7 @@ export interface HtmlAnnotationCfg extends HtmlComponentCfg {
   /** Y 方向对齐，默认 top */
   alignY?: 'top' | 'middle' | 'bottom';
   /** 自定义 html */
-  html: string | HTMLElement | ((container: HTMLElement) => void | string | HTMLElement);
+  html: string | number | HTMLElement | ((container: HTMLElement) => void | string | number | HTMLElement);
   /** zIndex 设置 */
   zIndex?: number;
 }

--- a/tests/unit/annotation/html-spec.ts
+++ b/tests/unit/annotation/html-spec.ts
@@ -117,6 +117,37 @@ describe('html annotation /w callback', () => {
     expect(container.innerHTML).toEqual(htmlStr);
   });
 
+  it('createDom', () => {
+    html.update({
+      x: 400,
+      y: 300,
+      html: '\\n',
+    });
+    html.render();
+    let container = parent.children[0] as HTMLElement;
+    expect(container.innerHTML).toBe('\\n');
+    expect(container.innerText).toBe('\\n');
+
+    html.update({
+      x: 400,
+      y: 300,
+      html: '\n',
+    });
+    html.render();
+    container = parent.children[0] as HTMLElement;
+    expect(container.innerHTML).toBe(`<div>\n</div>`);
+    expect(container.innerText).toBe('');
+
+    html.update({
+      x: 400,
+      y: 300,
+      html: 123,
+    });
+    html.render();
+    container = parent.children[0] as HTMLElement;
+    expect(container.innerHTML).toBe('123');
+  });
+
   it('destroy', () => {
     html.destroy();
     expect(html.destroyed).toBe(true);

--- a/tests/unit/annotation/html-spec.ts
+++ b/tests/unit/annotation/html-spec.ts
@@ -135,7 +135,17 @@ describe('html annotation /w callback', () => {
     });
     html.render();
     container = parent.children[0] as HTMLElement;
-    expect(container.innerHTML).toBe(`<div>\n</div>`);
+    expect(container.innerHTML).toBe('');
+    expect(container.innerText).toBe('');
+
+    html.update({
+      x: 400,
+      y: 300,
+      html: '',
+    });
+    html.render();
+    container = parent.children[0] as HTMLElement;
+    expect(container.innerHTML).toBe('');
     expect(container.innerText).toBe('');
 
     html.update({


### PR DESCRIPTION
`Html 组件报错` 
![image](https://user-images.githubusercontent.com/65594180/150945511-b85a06ee-727f-4d7f-918d-8af2f26df441.png)
`Html 组件修复`
![image](https://user-images.githubusercontent.com/65594180/150945697-f1f2b345-17cb-4fbb-a243-44047b7b2775.png)
