### PR TITLE
fix(annotationHtml): annotation html 在 container 没有绝对定位时获取宽度 宽度自适应导致 …

### DIFF
--- a/src/annotation/html.ts
+++ b/src/annotation/html.ts
@@ -15,7 +15,7 @@ export default class HtmlAnnotation extends HtmlComponent<HtmlAnnotationCfg> imp
       locationType: 'point',
       x: 0,
       y: 0,
-      containerTpl: `<div class="g2-html-annotation"></div>`,
+      containerTpl: `<div class="g2-html-annotation" style="position:absolute"></div>`,
       alignX: 'left',
       alignY: 'top',
       html: '',

--- a/tests/bugs/issue-annotation-html-spec.ts
+++ b/tests/bugs/issue-annotation-html-spec.ts
@@ -1,0 +1,36 @@
+import { Canvas } from '@antv/g-canvas';
+import HtmlAnnotation from '../../src/annotation/html';
+
+describe('html annotation alignX', () => {
+  const dom = document.createElement('div');
+  document.body.appendChild(dom);
+  dom.id = 'cant';
+  new Canvas({
+    container: 'cant',
+    width: 500,
+    height: 500,
+  });
+  const parent = document.createElement('div');
+  dom.appendChild(parent);
+
+  const html = new HtmlAnnotation({
+    parent,
+    html: '2222',
+    x: 400,
+    y: 200,
+    alignX: 'middle',
+  });
+
+  it('init', () => {
+    html.init();
+    html.render();
+    const container = parent.children[0] as HTMLElement;
+    expect(container.style.left).toBe('381px');
+  });
+
+  it('destroy', () => {
+    html.destroy();
+    expect(html.destroyed).toBe(true);
+    expect(parent.children).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
问题，html 在 alignX: 'middle' 时，使用自适应宽度进行了位置计算，倒是位置出错。
![image](https://user-images.githubusercontent.com/65594180/183861764-d59ef9ad-82ca-4030-a654-85553d291b0a.png)


![image](https://user-images.githubusercontent.com/65594180/183861500-cc7bbfb4-a77b-4585-88eb-142f3c5c6589.png)

