### PR TITLE
chore: v0.8.28 & changelog 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+#### 0.8.28 (2022-08-10)
+
+##### Bug Fixes
+
+- **annotation:** annotation html 在 container 没有绝对定位时获取宽度宽度自适应导致位置计算出错的问题。 ([#272](https://github.com/antvis/component/pull/272)) ([e930d028](https://github.com/antvis/component/pull/272/commits/e930d02846f2ec7b3136e94ddc9bad6d7b5a63fd))
+
 #### 0.8.27 (2022-04-12)
 
 ##### New Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/component",
-  "version": "0.8.27",
+  "version": "0.8.28",
   "description": "The component module for antv",
   "author": "https://github.com/orgs/antvis/people",
   "license": "MIT",

--- a/src/annotation/html.ts
+++ b/src/annotation/html.ts
@@ -15,7 +15,7 @@ export default class HtmlAnnotation extends HtmlComponent<HtmlAnnotationCfg> imp
       locationType: 'point',
       x: 0,
       y: 0,
-      containerTpl: `<div class="g2-html-annotation"></div>`,
+      containerTpl: `<div class="g2-html-annotation" style="position:absolute"></div>`,
       alignX: 'left',
       alignY: 'top',
       html: '',

--- a/tests/bugs/issue-annotation-html-spec.ts
+++ b/tests/bugs/issue-annotation-html-spec.ts
@@ -1,0 +1,36 @@
+import { Canvas } from '@antv/g-canvas';
+import HtmlAnnotation from '../../src/annotation/html';
+
+describe('html annotation alignX', () => {
+  const dom = document.createElement('div');
+  document.body.appendChild(dom);
+  dom.id = 'cant';
+  new Canvas({
+    container: 'cant',
+    width: 500,
+    height: 500,
+  });
+  const parent = document.createElement('div');
+  dom.appendChild(parent);
+
+  const html = new HtmlAnnotation({
+    parent,
+    html: '2222',
+    x: 400,
+    y: 200,
+    alignX: 'middle',
+  });
+
+  it('init', () => {
+    html.init();
+    html.render();
+    const container = parent.children[0] as HTMLElement;
+    expect(container.style.left).toBe('381px');
+  });
+
+  it('destroy', () => {
+    html.destroy();
+    expect(html.destroyed).toBe(true);
+    expect(parent.children).toHaveLength(0);
+  });
+});


### PR DESCRIPTION

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

