### PR TITLE
fix(tooltip): 修复自定义 tooltip 的动画没有 transition 效果

### DIFF
--- a/src/tooltip/html.ts
+++ b/src/tooltip/html.ts
@@ -197,15 +197,11 @@ class Tooltip<T extends TooltipCfg = TooltipCfg> extends HtmlComponent implement
 
   // 根据 customContent 渲染
   private renderCustomContent() {
-    const node = this.getHtmlContentNode();
-    const parent: HTMLElement = this.get('parent');
-    const curContainer: HTMLElement = this.get('container');
-    if (curContainer && curContainer.parentNode === parent) {
-      parent.replaceChild(node, curContainer);
-    } else {
-      parent.appendChild(node);
-    }
-    this.set('container', node);
+    const newContainer = this.getHtmlContentNode();
+    const oldContainer: HTMLElement = this.get('container');
+    oldContainer.innerHTML = '';
+    const newChild = newContainer.children[0];
+    oldContainer.appendChild(newChild);
     this.resetStyles();
     this.applyStyles();
   }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->

tooltip 有2种展示方式, 默认的和自定义的. 而自定义的tooltip在跟随鼠标移动时, 会表现的卡顿. 实际原因就是dom的transition没有生效, 根本原因是每次鼠标滑动都会产生一个新的dom, 然后执行replaceChild. 