### PR TITLE
fix(tooltip): 修复当 customContent 传入非 DOM 或单一 DOM 结构无法渲染的问题

### DIFF
--- a/src/tooltip/html.ts
+++ b/src/tooltip/html.ts
@@ -10,6 +10,7 @@ import TooltipTheme from './html-theme';
 
 import { ILocation } from '../interfaces';
 import { getAlignPoint } from '../util/align';
+import { CONTAINER_CLASS } from './css-const';
 
 function hasOneKey(obj, keys) {
   let result = false;
@@ -138,9 +139,12 @@ class Tooltip<T extends TooltipCfg = TooltipCfg> extends HtmlComponent implement
       if (this.get('container')) {
         this.get('container').remove();
       }
-      const container = this.getHtmlContentNode();
-      this.get('parent').appendChild(container);
-      this.set('container', container);
+      const newContainer = this.getHtmlContentNode();
+      const customContainer = document.createElement('div');
+      customContainer.className = CONTAINER_CLASS;
+      customContainer.appendChild(newContainer);
+      this.get('parent').appendChild(customContainer);
+      this.set('container', customContainer);
       this.resetStyles();
       this.applyStyles();
     }
@@ -200,8 +204,7 @@ class Tooltip<T extends TooltipCfg = TooltipCfg> extends HtmlComponent implement
     const newContainer = this.getHtmlContentNode();
     const oldContainer: HTMLElement = this.get('container');
     oldContainer.innerHTML = '';
-    const newChild = newContainer.children[0];
-    oldContainer.appendChild(newChild);
+    oldContainer.appendChild(newContainer);
     this.resetStyles();
     this.applyStyles();
   }

--- a/tests/unit/tooltip/html-spec.ts
+++ b/tests/unit/tooltip/html-spec.ts
@@ -314,6 +314,8 @@ describe('test tooltip', () => {
       tooltip.init();
       container = tooltip.getContainer();
       expect(Array.from(container.classList).includes('g2-tooltip')).toBe(true);
+      const target = container.getElementsByClassName('custom-html-tooltip');
+      expect(target.length).toBe(1);
       each(HtmlTheme[CssConst.CONTAINER_CLASS], (val, key) => {
         if (!['transition', 'boxShadow', 'fontFamily', 'padding'].includes(key)) {
           expect(container.style[key] + '').toBe(val + '');
@@ -325,6 +327,8 @@ describe('test tooltip', () => {
       tooltip.render();
       container = tooltip.getContainer();
       expect(Array.from(container.classList).includes('g2-tooltip')).toBe(true);
+      const target = container.getElementsByClassName('custom-html-tooltip');
+      expect(target.length).toBe(1);
       const title = container.getElementsByClassName('g2-tooltip-title')[0] as HTMLElement;
       expect(title.innerText).toBe('My Title html');
       const listItems = Array.from(container.getElementsByClassName('g2-tooltip-list-item')) as HTMLElement[];

--- a/tests/unit/tooltip/html-spec.ts
+++ b/tests/unit/tooltip/html-spec.ts
@@ -314,7 +314,6 @@ describe('test tooltip', () => {
       tooltip.init();
       container = tooltip.getContainer();
       expect(Array.from(container.classList).includes('g2-tooltip')).toBe(true);
-      expect(Array.from(container.classList).includes('custom-html-tooltip')).toBe(true);
       each(HtmlTheme[CssConst.CONTAINER_CLASS], (val, key) => {
         if (!['transition', 'boxShadow', 'fontFamily', 'padding'].includes(key)) {
           expect(container.style[key] + '').toBe(val + '');
@@ -326,7 +325,6 @@ describe('test tooltip', () => {
       tooltip.render();
       container = tooltip.getContainer();
       expect(Array.from(container.classList).includes('g2-tooltip')).toBe(true);
-      expect(Array.from(container.classList).includes('custom-html-tooltip')).toBe(true);
       const title = container.getElementsByClassName('g2-tooltip-title')[0] as HTMLElement;
       expect(title.innerText).toBe('My Title html');
       const listItems = Array.from(container.getElementsByClassName('g2-tooltip-list-item')) as HTMLElement[];


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->

在之前的版本中, `customContent`必须返回一个DOM, 否则会没有效果. 本次修改就是修复了这个场景问题, 无论`customContent`返回什么, 都能够顺利出现在`tooltip`组件中.