### PR TITLE
fix(tooltip): 创建全新容器类名以兼容线上业务

### DIFF
--- a/src/abstract/html-component.ts
+++ b/src/abstract/html-component.ts
@@ -1,5 +1,6 @@
 import { createDom, modifyCSS } from '@antv/dom-util';
 import { isNil, isString, deepMix, each, hasKey } from '@antv/util';
+import { CONTAINER_CLASS_CUSTOM } from '../tooltip/css-const';
 import { BBox, ComponentCfg, HtmlComponentCfg } from '../types';
 import { clearDom, createBBox, hasClass } from '../util/util';
 import Component from './component';
@@ -91,9 +92,7 @@ abstract class HtmlComponent<T extends ComponentCfg = HtmlComponentCfg> extends 
     }
   }
 
-  protected initDom() {
-
-  }
+  protected initDom() {}
 
   protected initContainer() {
     let container = this.get('container');
@@ -150,6 +149,11 @@ abstract class HtmlComponent<T extends ComponentCfg = HtmlComponentCfg> extends 
     each(styles, (style, name) => {
       const elements = element.getElementsByClassName(name);
       each(elements, (el) => {
+        const containerClassName = this.get('containerClassName');
+        // 在自定义容器下, 可以渲染 g2-tooltip 的样式, 以兼容线上场景, 但是不应该设置 visibility
+        if (containerClassName === CONTAINER_CLASS_CUSTOM) {
+          delete style.visibility;
+        }
         modifyCSS(el, style);
       });
     });
@@ -172,7 +176,7 @@ abstract class HtmlComponent<T extends ComponentCfg = HtmlComponentCfg> extends 
    * @protected
    * 初始化事件
    */
-  protected initEvent() { }
+  protected initEvent() {}
 
   /**
    * @protected
@@ -188,7 +192,7 @@ abstract class HtmlComponent<T extends ComponentCfg = HtmlComponentCfg> extends 
    * @protected
    * 清理事件
    */
-  protected removeEvent() { }
+  protected removeEvent() {}
 
   protected updateInner(cfg) {
     // 更新样式
@@ -199,7 +203,7 @@ abstract class HtmlComponent<T extends ComponentCfg = HtmlComponentCfg> extends 
     // 只要属性发生变化，都调整一些位置
     this.resetPosition();
   }
-  protected resetPosition() { };
+  protected resetPosition() {}
 }
 
 export default HtmlComponent;

--- a/src/tooltip/css-const.ts
+++ b/src/tooltip/css-const.ts
@@ -1,4 +1,5 @@
 export const CONTAINER_CLASS = 'g2-tooltip';
+export const CONTAINER_CLASS_CUSTOM = 'g2-tooltip-custom';
 export const TITLE_CLASS = 'g2-tooltip-title';
 export const LIST_CLASS = 'g2-tooltip-list';
 export const LIST_ITEM_CLASS = 'g2-tooltip-list-item';

--- a/src/tooltip/html-theme.ts
+++ b/src/tooltip/html-theme.ts
@@ -24,6 +24,14 @@ export default {
     lineHeight: '20px',
     padding: '10px 10px 6px 10px',
   },
+  [`${CssConst.CONTAINER_CLASS_CUSTOM}`]: {
+    position: 'absolute',
+    zIndex: 8,
+    transition:
+      'visibility 0.2s cubic-bezier(0.23, 1, 0.32, 1), ' +
+      'left 0.4s cubic-bezier(0.23, 1, 0.32, 1), ' +
+      'top 0.4s cubic-bezier(0.23, 1, 0.32, 1)',
+  },
   [`${CssConst.TITLE_CLASS}`]: {
     marginBottom: '4px',
   },

--- a/src/tooltip/html.ts
+++ b/src/tooltip/html.ts
@@ -10,7 +10,7 @@ import TooltipTheme from './html-theme';
 
 import { ILocation } from '../interfaces';
 import { getAlignPoint } from '../util/align';
-import { CONTAINER_CLASS } from './css-const';
+import { CONTAINER_CLASS_CUSTOM } from './css-const';
 
 function hasOneKey(obj, keys) {
   let result = false;
@@ -141,10 +141,11 @@ class Tooltip<T extends TooltipCfg = TooltipCfg> extends HtmlComponent implement
       }
       const newContainer = this.getHtmlContentNode();
       const customContainer = document.createElement('div');
-      customContainer.className = CONTAINER_CLASS;
+      customContainer.className = CONTAINER_CLASS_CUSTOM;
       customContainer.appendChild(newContainer);
       this.get('parent').appendChild(customContainer);
       this.set('container', customContainer);
+      this.set('containerClassName', CONTAINER_CLASS_CUSTOM);
       this.resetStyles();
       this.applyStyles();
     }

--- a/tests/unit/tooltip/html-spec.ts
+++ b/tests/unit/tooltip/html-spec.ts
@@ -313,10 +313,10 @@ describe('test tooltip', () => {
     it('init', () => {
       tooltip.init();
       container = tooltip.getContainer();
-      expect(Array.from(container.classList).includes('g2-tooltip')).toBe(true);
+      expect(Array.from(container.classList).includes(CssConst.CONTAINER_CLASS_CUSTOM)).toBe(true);
       const target = container.getElementsByClassName('custom-html-tooltip');
       expect(target.length).toBe(1);
-      each(HtmlTheme[CssConst.CONTAINER_CLASS], (val, key) => {
+      each(HtmlTheme[CssConst.CONTAINER_CLASS_CUSTOM], (val, key) => {
         if (!['transition', 'boxShadow', 'fontFamily', 'padding'].includes(key)) {
           expect(container.style[key] + '').toBe(val + '');
         }
@@ -326,7 +326,7 @@ describe('test tooltip', () => {
     it('render', () => {
       tooltip.render();
       container = tooltip.getContainer();
-      expect(Array.from(container.classList).includes('g2-tooltip')).toBe(true);
+      expect(Array.from(container.classList).includes(CssConst.CONTAINER_CLASS_CUSTOM)).toBe(true);
       const target = container.getElementsByClassName('custom-html-tooltip');
       expect(target.length).toBe(1);
       const title = container.getElementsByClassName('g2-tooltip-title')[0] as HTMLElement;
@@ -336,7 +336,7 @@ describe('test tooltip', () => {
         expect(Array.from(listItem.classList).includes('my-list-item')).toBe(true);
         expect(listItem.innerText).toBe(`My Value: ${items[index].value}`);
       });
-      each(HtmlTheme[CssConst.CONTAINER_CLASS], (val, key) => {
+      each(HtmlTheme[CssConst.CONTAINER_CLASS_CUSTOM], (val, key) => {
         if (!['transition', 'boxShadow', 'fontFamily', 'padding'].includes(key)) {
           expect(container.style[key] + '').toBe(val + '');
         }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->

在之前的tooltip改法, 存在场景兼容的问题. 现在重新定义容器的类名, 并且只控制位置, 不添加其他样式. 这样一来, 不管用户在线上返回的回调函数结果是什么样的, 都是正常渲染. 咱们只控制位置.