### PR TITLE
Revert "fix(tooltip): 修复当 customContent 传入非 DOM 或单一 DOM 结构无法渲染的问题"

### DIFF
--- a/src/tooltip/html.ts
+++ b/src/tooltip/html.ts
@@ -10,7 +10,6 @@ import TooltipTheme from './html-theme';
 
 import { ILocation } from '../interfaces';
 import { getAlignPoint } from '../util/align';
-import { CONTAINER_CLASS } from './css-const';
 
 function hasOneKey(obj, keys) {
   let result = false;
@@ -139,12 +138,9 @@ class Tooltip<T extends TooltipCfg = TooltipCfg> extends HtmlComponent implement
       if (this.get('container')) {
         this.get('container').remove();
       }
-      const newContainer = this.getHtmlContentNode();
-      const customContainer = document.createElement('div');
-      customContainer.className = CONTAINER_CLASS;
-      customContainer.appendChild(newContainer);
-      this.get('parent').appendChild(customContainer);
-      this.set('container', customContainer);
+      const container = this.getHtmlContentNode();
+      this.get('parent').appendChild(container);
+      this.set('container', container);
       this.resetStyles();
       this.applyStyles();
     }
@@ -204,7 +200,8 @@ class Tooltip<T extends TooltipCfg = TooltipCfg> extends HtmlComponent implement
     const newContainer = this.getHtmlContentNode();
     const oldContainer: HTMLElement = this.get('container');
     oldContainer.innerHTML = '';
-    oldContainer.appendChild(newContainer);
+    const newChild = newContainer.children[0];
+    oldContainer.appendChild(newChild);
     this.resetStyles();
     this.applyStyles();
   }

--- a/tests/unit/tooltip/html-spec.ts
+++ b/tests/unit/tooltip/html-spec.ts
@@ -314,8 +314,7 @@ describe('test tooltip', () => {
       tooltip.init();
       container = tooltip.getContainer();
       expect(Array.from(container.classList).includes('g2-tooltip')).toBe(true);
-      const target = container.getElementsByClassName('custom-html-tooltip');
-      expect(target.length).toBe(1);
+      expect(Array.from(container.classList).includes('custom-html-tooltip')).toBe(true);
       each(HtmlTheme[CssConst.CONTAINER_CLASS], (val, key) => {
         if (!['transition', 'boxShadow', 'fontFamily', 'padding'].includes(key)) {
           expect(container.style[key] + '').toBe(val + '');
@@ -327,8 +326,7 @@ describe('test tooltip', () => {
       tooltip.render();
       container = tooltip.getContainer();
       expect(Array.from(container.classList).includes('g2-tooltip')).toBe(true);
-      const target = container.getElementsByClassName('custom-html-tooltip');
-      expect(target.length).toBe(1);
+      expect(Array.from(container.classList).includes('custom-html-tooltip')).toBe(true);
       const title = container.getElementsByClassName('g2-tooltip-title')[0] as HTMLElement;
       expect(title.innerText).toBe('My Title html');
       const listItems = Array.from(container.getElementsByClassName('g2-tooltip-list-item')) as HTMLElement[];


### PR DESCRIPTION
Reverts antvis/component#277