### PR TITLE
fix: keep container stable when customcontent changed in tooltip

### DIFF
--- a/src/tooltip/html.ts
+++ b/src/tooltip/html.ts
@@ -200,17 +200,33 @@ class Tooltip<T extends TooltipCfg = TooltipCfg> extends HtmlComponent implement
     const node = this.getHtmlContentNode();
     const parent: HTMLElement = this.get('parent');
     const curContainer: HTMLElement = this.get('container');
+    let needSyncClassNameAndStyle = false;
     if (curContainer && curContainer.parentNode === parent) {
+      needSyncClassNameAndStyle = true;
       // keep `curContainer` stable, just replace children
       // @see https://developer.mozilla.org/zh-CN/docs/Web/API/Element/replaceChildren
       curContainer.innerHTML = '';
-      curContainer.append(...Array.from(node.children));
+      if (node.children.length) {
+        curContainer.append(...Array.from(node.children));
+      } else {
+        curContainer.innerHTML = node.innerHTML;
+      }
     } else {
       parent.appendChild(node);
       this.set('container', node);
     }
     this.resetStyles();
     this.applyStyles();
+
+    if (needSyncClassNameAndStyle) {
+      const container = this.get('container');
+      container.className = '';
+      const containerClassName = this.get('containerClassName');
+      curContainer.classList.add(containerClassName, ...Array.from(node.classList));
+
+      // append user-defined inline style if needed
+      curContainer.style.cssText += node.style.cssText;
+    }
   }
 
   private getHtmlContentNode() {

--- a/src/tooltip/html.ts
+++ b/src/tooltip/html.ts
@@ -201,11 +201,14 @@ class Tooltip<T extends TooltipCfg = TooltipCfg> extends HtmlComponent implement
     const parent: HTMLElement = this.get('parent');
     const curContainer: HTMLElement = this.get('container');
     if (curContainer && curContainer.parentNode === parent) {
-      parent.replaceChild(node, curContainer);
+      // keep `curContainer` stable, just replace children
+      // @see https://developer.mozilla.org/zh-CN/docs/Web/API/Element/replaceChildren
+      curContainer.innerHTML = '';
+      curContainer.append(...Array.from(node.children));
     } else {
       parent.appendChild(node);
+      this.set('container', node);
     }
-    this.set('container', node);
     this.resetStyles();
     this.applyStyles();
   }

--- a/tests/unit/tooltip/html-spec.ts
+++ b/tests/unit/tooltip/html-spec.ts
@@ -279,7 +279,7 @@ describe('test tooltip', () => {
     });
   });
 
-  describe('customContent', () => {
+  describe.only('customContent', () => {
     const items = [
       { name: 'china', value: '100' },
       { name: 'india', value: '200' },
@@ -349,6 +349,43 @@ describe('test tooltip', () => {
           });
         });
       });
+
+      tooltip.update({
+        customContent: (title: string, data: any[]) => {
+          return `
+            <div class="g2-tooltip updated-html-tooltip" style="background: red;">
+              text
+            </div>
+            `;
+        },
+      });
+      expect(Array.from(container.classList).includes('g2-tooltip')).toBe(true);
+      expect(Array.from(container.classList).includes('custom-html-tooltip')).toBe(false);
+      expect(Array.from(container.classList).includes('updated-html-tooltip')).toBe(true);
+      expect(container.innerHTML.trim()).toBe('text');
+
+      tooltip.update({
+        customContent: (title: string, data: any[]) => {
+          return `
+          <div class="g2-tooltip custom-html-tooltip">
+            <div class="g2-tooltip-title">My Title ${title}</div>
+            <ul class="g2-tooltip-list">
+              ${data
+                .map(
+                  (item) => `
+                <li class="g2-tooltip-list-item my-list-item">My Value: ${item.value}<li>
+              `
+                )
+                .join('')}
+            </ul>
+          </div>
+          `;
+        },
+      });
+
+      expect(Array.from(container.classList).includes('g2-tooltip')).toBe(true);
+      expect(Array.from(container.classList).includes('custom-html-tooltip')).toBe(true);
+      expect(Array.from(container.classList).includes('updated-html-tooltip')).toBe(false);
     });
 
     it('hide/show', () => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->

#282

正如 [Eve-Sama](https://github.com/Eve-Sama) 发现的，其本质原因是 Tooltip 容器存在被 `replaceChild` 整体替换为自定义内容的可能，导致应用其上的 `transition` 样式无效。

解决方法就是保持容器稳定，更新时仅替换全部子节点。
DOM API 提供了 [replaceChildren](https://developer.mozilla.org/en-US/docs/Web/API/Element/replaceChildren) 方法，但考虑到兼容性，使用清空 + `append` 的方式：https://github.com/zloirock/core-js/issues/940

虽然能解决，但不加约束的自定义内容仍有可能引发后续问题。
如果后面设计新版 Tooltip，建议还是明确自定义的范围，不让用户感知到容器的存在，如果想修改样式，提供类似 antd 组件的 `tooltipClassName` 即可：

```js
// before
customContent: (title: string, data: any[]) => {
  return `
    <div class="g2-tooltip custom-html-tooltip">
      <my-content />
    </div>
  `;
}

// after
tooltipClassName: 'custom-html-tooltip',
customContent: (title: string, data: any[]) => {
  return `
      <my-content />
  `;
}
```