### PR TITLE
fix(slider): move interaction does not work in mobile & fix text size bug

### DIFF
--- a/src/slider/constant.ts
+++ b/src/slider/constant.ts
@@ -34,22 +34,21 @@ export const BACKGROUND_STYLE = {
 export const FOREGROUND_STYLE = {
   fill: '#3485F8',
   opacity: 0.06,
+  stroke: '#4E83CD',
+  strokeOpacity: 0.3,
+  lineWidth: 0.8,
 };
 
-export const SLIDER_BAR_STYLE = {
+export const SLIDER_BAR_LINE_GAP = 4;
+export const SLIDER_BAR_HEIGHT = 6;
+export const BAR_STYLE = {
   fill: '#DEE6F2',
+  height: SLIDER_BAR_HEIGHT,
   highLightFill: '#CBDEF8',
-};
-
-export const SLICER_BAR_LINE_STYLE = {
   stroke: '#FFF',
   lineWidth: 1.2,
   cursor: 'move',
 };
-
-export const SLIDER_BAR_LINE_GAP = 4;
-
-export const SLIDER_BAR_HEIGHT = 6;
 
 export const DEFAULT_HANDLER_WIDTH = 6;
 export const DEFAULT_HANDLER_HEIGHT = 12;

--- a/src/slider/foreground.ts
+++ b/src/slider/foreground.ts
@@ -1,13 +1,8 @@
 import { IGroup, LooseObject } from '@antv/g-base';
+import { omit } from '@antv/util';
 import GroupComponent from '../abstract/group-component';
 import { GroupComponentCfg } from '../types';
-import {
-  FOREGROUND_STYLE,
-  SLICER_BAR_LINE_STYLE,
-  SLIDER_BAR_HEIGHT,
-  SLIDER_BAR_LINE_GAP,
-  SLIDER_BAR_STYLE,
-} from './constant';
+import { BAR_STYLE, FOREGROUND_STYLE, SLIDER_BAR_LINE_GAP } from './constant';
 
 interface IStyle {
   fill?: string;
@@ -34,17 +29,15 @@ export class Foreground extends GroupComponent<ForegroundCfg> {
     return {
       ...cfg,
       name: 'foreground',
-      // x: 0,
-      // y: 0,
       width: 100,
       height: 16,
-      style: FOREGROUND_STYLE,
-      barStyle: SLIDER_BAR_STYLE,
+      foregroundStyle: FOREGROUND_STYLE,
+      barStyle: BAR_STYLE,
     };
   }
 
   protected renderInner(group: IGroup) {
-    const { x, height, width, style, barStyle } = this.cfg;
+    const { x, height, width, foregroundStyle, barStyle } = this.cfg;
 
     // 上方brush区域
     this.addShape(group, {
@@ -57,7 +50,7 @@ export class Foreground extends GroupComponent<ForegroundCfg> {
         width,
         height: (height * 3) / 5,
         cursor: 'crosshair',
-        ...style,
+        ...omit(foregroundStyle, ['stroke']),
       },
     });
 
@@ -72,7 +65,7 @@ export class Foreground extends GroupComponent<ForegroundCfg> {
         width,
         height: (height * 2) / 5,
         cursor: 'move',
-        ...style,
+        ...omit(foregroundStyle, ['stroke']),
       },
     });
 
@@ -90,7 +83,7 @@ export class Foreground extends GroupComponent<ForegroundCfg> {
         x,
         y: height,
         width,
-        height: SLIDER_BAR_HEIGHT,
+        height: barStyle.height,
         cursor: 'move',
         ...barStyle,
       },
@@ -99,12 +92,12 @@ export class Foreground extends GroupComponent<ForegroundCfg> {
     const centerX = width / 2 + x;
     const leftX = centerX - SLIDER_BAR_LINE_GAP;
     const rightX = centerX + SLIDER_BAR_LINE_GAP;
-    const y1 = height + (1 / 5) * 6;
-    const y2 = height + (4 / 5) * 6;
+    const y1 = height + (1 / 4) * barStyle.height;
+    const y2 = height + (3 / 4) * barStyle.height;
     const publicAttrs = {
       y1,
       y2,
-      ...SLICER_BAR_LINE_STYLE,
+      ...barStyle,
     };
     [leftX, centerX, rightX].forEach((x) => {
       this.drawBarLine(group, x, publicAttrs);
@@ -119,9 +112,9 @@ export class Foreground extends GroupComponent<ForegroundCfg> {
         y: 0,
         width,
         height,
-        stroke: '#4E83CD',
-        opacity: 0.3,
-        lineWidth: 0.8,
+        stroke: foregroundStyle?.stroke,
+        opacity: foregroundStyle?.strokeOpacity,
+        lineWidth: foregroundStyle?.lineWidth,
       },
     });
   }

--- a/src/util/event.ts
+++ b/src/util/event.ts
@@ -1,4 +1,4 @@
-import { Event, IGroup } from '@antv/g-base';
+import { IGroup } from '@antv/g-base';
 import { Event as GraphEvent } from '@antv/g-base';
 import { get } from '@antv/util';
 import { LooseObject } from '../types';
@@ -28,8 +28,7 @@ export function propagationDelegate(group: IGroup, eventName: string, eventObjec
  *
  * @param e 事件对象
  */
-export function getCurrentPoint(e: Event) {
-  const event = e.originalEvent as MouseEvent;
+export function getCurrentPoint(event: MouseEvent) {
   return {
     x: get(event, 'touches.0.pageX', event.pageX),
     y: get(event, 'touches.0.pageY', event.pageY),

--- a/src/util/mask.ts
+++ b/src/util/mask.ts
@@ -1,4 +1,4 @@
-import { BBox, IGroup, IShape, LooseObject, Point } from '@antv/g-base';
+import { IGroup, IShape, LooseObject, Point } from '@antv/g-base';
 
 export function createMask(group: IGroup, maskType: string, maskAttrs: LooseObject) {
   const maskShape = group.addShape({
@@ -17,15 +17,6 @@ export function updateMask(shape: IShape, maskAttrs: LooseObject) {
   shape.attr(maskAttrs);
   return shape;
 }
-
-// export function overBBoxLimit(bbox: BBox, curPoint: Point) {
-//   const { minX, maxX, minY, maxY } = bbox;
-//   const { x, y } = curPoint;
-//   if (Math.min(minX, maxX) > x || Math.max(minX, maxX) < x || Math.min(minY, maxY) > y || Math.max(minY, maxY) < y) {
-//     return true;
-//   }
-//   return false;
-// }
 
 export function getRectMaskAttrs(start: Point, end: Point) {
   const x = Math.min(start.x, end.x);

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -265,7 +265,10 @@ export function getTextWidth(text: string, font: string) {
   return width;
 }
 
-export function clipText(str: string, maxWidth: number, font: string) {
+/**
+ * @description 文字超出最大宽度时，换行处理
+ */
+export function clipTextTwoLines(str: string, maxWidth: number, font: string) {
   // 日期字段根据空格拆为两组：'2022-10-12 08:23' => ['2022-10-12', '08:23']
   if (Date.parse(str)) {
     return str.split(' ').join('\n');
@@ -274,7 +277,7 @@ export function clipText(str: string, maxWidth: number, font: string) {
   function mapStr(str: string, callback: (i: number) => void) {
     for (let i = 0; i < str.length; i++) {
       const curStr = str.slice(0, i + 1);
-      const curWidth = getTextWidth(curStr, '12');
+      const curWidth = getTextWidth(curStr, font);
       if (curWidth > maxWidth) {
         callback(i);
         return;

--- a/tests/unit/component/group-simple-spec.ts
+++ b/tests/unit/component/group-simple-spec.ts
@@ -209,7 +209,7 @@ describe('test simple component', () => {
     setTimeout(() => {
       expect(b.get('group').getChildren().length).toBe(1);
       done();
-    }, 600);
+    }, 1000);
   });
 
   it('add Animate', (done) => {
@@ -232,7 +232,7 @@ describe('test simple component', () => {
     setTimeout(() => {
       expect(bShape.attr('opacity')).toBe(1);
       done();
-    }, 550);
+    }, 600);
   });
 
   it('destroy', () => {


### PR DESCRIPTION
#### 功能描述
- 修复 slider 组件移动端移动事件失效问题
![iShot_2023-02-17_16 41 00](https://user-images.githubusercontent.com/109653633/219595675-7aff4828-b08c-4d53-96ac-ff83363c1c9f.gif)

- 修复 slider 组件在长文本下文字

| Before | After |
|--------|-------|
| <img width="246" alt="image" src="https://user-images.githubusercontent.com/109653633/219596239-0683b974-2dc0-4d18-bc24-d6dad23b63ac.png"> | <img width="227" alt="image" src="https://user-images.githubusercontent.com/109653633/219596368-0adaa070-9301-4a66-96c5-7be43a333760.png"> |

- 支持传入 barStyle 定制下方 bar 样式
