### PR TITLE
feat: change brush and move position & hode highlight fill when move

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/component",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "The component module for antv",
   "author": "https://github.com/orgs/antvis/people",
   "license": "MIT",

--- a/src/slider/constant.ts
+++ b/src/slider/constant.ts
@@ -42,17 +42,17 @@ export const FOREGROUND_STYLE = {
 export const SLIDER_BAR_LINE_GAP = 4;
 export const SLIDER_BAR_HEIGHT = 6;
 export const BAR_STYLE = {
-  fill: '#DEE6F2',
   height: SLIDER_BAR_HEIGHT,
+  fill: '#DEE6F2',
   highLightFill: '#CBDEF8',
   stroke: '#FFF',
   lineWidth: 1.2,
   cursor: 'move',
+  radius: [2, 2, 0, 0],
 };
 
 export const DEFAULT_HANDLER_WIDTH = 6;
 export const DEFAULT_HANDLER_HEIGHT = 12;
-
 export const HANDLER_STYLE = {
   width: DEFAULT_HANDLER_WIDTH,
   height: DEFAULT_HANDLER_HEIGHT,

--- a/src/slider/foreground.ts
+++ b/src/slider/foreground.ts
@@ -39,29 +39,14 @@ export class Foreground extends GroupComponent<ForegroundCfg> {
   protected renderInner(group: IGroup) {
     const { x, height, width, foregroundStyle, barStyle } = this.cfg;
 
-    // 上方brush区域
-    this.addShape(group, {
-      id: this.getElementId('foreground-brush'),
-      name: 'foreground-brush',
-      type: 'rect',
-      attrs: {
-        x,
-        y: 0,
-        width,
-        height: (height * 3) / 5,
-        cursor: 'crosshair',
-        ...omit(foregroundStyle, ['stroke']),
-      },
-    });
-
-    // 下方移动区域
+    // 上方移动区域
     this.addShape(group, {
       id: this.getElementId('foreground-scroll'),
       name: 'foreground-scroll',
       type: 'rect',
       attrs: {
         x,
-        y: (height * 3) / 5,
+        y: 0,
         width,
         height: (height * 2) / 5,
         cursor: 'move',
@@ -69,7 +54,22 @@ export class Foreground extends GroupComponent<ForegroundCfg> {
       },
     });
 
-    // 下方Bar区域
+    // 下方brush区域
+    this.addShape(group, {
+      id: this.getElementId('foreground-brush'),
+      name: 'foreground-brush',
+      type: 'rect',
+      attrs: {
+        x,
+        y: (height * 2) / 5,
+        width,
+        height: (height * 3) / 5,
+        cursor: 'crosshair',
+        ...omit(foregroundStyle, ['stroke']),
+      },
+    });
+
+    // 上方Bar区域
     const barGroup = this.addGroup(group, {
       id: this.getElementId('foreground-bar'),
       name: 'foreground-bar',
@@ -81,19 +81,19 @@ export class Foreground extends GroupComponent<ForegroundCfg> {
       type: 'rect',
       attrs: {
         x,
-        y: height,
+        y: -barStyle.height,
         width,
         height: barStyle.height,
         cursor: 'move',
-        ...barStyle,
+        ...omit(barStyle, ['stroke']),
       },
     });
     // 三条小竖线
     const centerX = width / 2 + x;
     const leftX = centerX - SLIDER_BAR_LINE_GAP;
     const rightX = centerX + SLIDER_BAR_LINE_GAP;
-    const y1 = height + (1 / 4) * barStyle.height;
-    const y2 = height + (3 / 4) * barStyle.height;
+    const y1 = -(1 / 4) * barStyle.height;
+    const y2 = -(3 / 4) * barStyle.height;
     const publicAttrs = {
       y1,
       y2,
@@ -103,6 +103,7 @@ export class Foreground extends GroupComponent<ForegroundCfg> {
       this.drawBarLine(group, x, publicAttrs);
     });
 
+    // 背景边框
     this.addShape(group, {
       id: this.getElementId('foreground-border'),
       name: 'foreground-border',
@@ -122,7 +123,7 @@ export class Foreground extends GroupComponent<ForegroundCfg> {
   private drawBarLine(group: IGroup, x: number, attrs: LooseObject) {
     this.addShape(group, {
       id: this.getElementId(`line-${x}`),
-      name: `line-${x}`,
+      name: `foreground-line`,
       type: 'line',
       attrs: {
         x1: x,
@@ -143,7 +144,15 @@ export class Foreground extends GroupComponent<ForegroundCfg> {
       barRectShape.attr('fill', highLightFill);
       this.draw();
     });
+    this.get('group').on('foreground-scroll:mouseenter', () => {
+      barRectShape.attr('fill', highLightFill);
+      this.draw();
+    });
     this.get('group').on('foreground-bar:mouseleave', () => {
+      barRectShape.attr('fill', fill);
+      this.draw();
+    });
+    this.get('group').on('foreground-scroll:mouseleave', () => {
       barRectShape.attr('fill', fill);
       this.draw();
     });

--- a/src/slider/handler.ts
+++ b/src/slider/handler.ts
@@ -10,6 +10,7 @@ interface IStyle {
   opacity?: number;
   cursor?: string;
   highLightFill?: string;
+  highLightStroke?: string;
 }
 
 export interface HandlerCfg extends GroupComponentCfg {
@@ -64,6 +65,7 @@ export class Handler extends GroupComponent<HandlerCfg> {
 
     this.addShape(group, {
       id: this.getElementId('line-left'),
+      name: 'handler-line',
       type: 'line',
       attrs: {
         x1,
@@ -77,6 +79,7 @@ export class Handler extends GroupComponent<HandlerCfg> {
 
     this.addShape(group, {
       id: this.getElementId('line-right'),
+      name: 'handler-line',
       type: 'line',
       attrs: {
         x1: x2,

--- a/src/slider/slider.ts
+++ b/src/slider/slider.ts
@@ -304,7 +304,7 @@ export class Slider extends GroupComponent<SliderCfg> implements ISlider {
   }
 
   private updateUI(minTextShape: IShape, maxTextShape: IShape) {
-    const { start, end, width, minText, maxText, handlerStyle, height } = this.cfg as SliderCfg;
+    const { start, end, width, minText, maxText, handlerStyle, height, barStyle } = this.cfg;
     const min = start * width;
     const max = end * width;
 
@@ -319,27 +319,37 @@ export class Slider extends GroupComponent<SliderCfg> implements ISlider {
     }
 
     if (this.foreground) {
+      const newBarStyle = ['foreground-bar', 'foreground'].includes(this.currentTarget)
+        ? { ...barStyle, fill: barStyle.highLightFill }
+        : barStyle;
       this.foreground.update({
         x: min,
         width: max - min,
+        barStyle: newBarStyle,
       });
       if (!this.get('updateAutoRender')) {
         this.foreground.render();
       }
     }
-
     // 滑块相关的大小信息
     const handlerWidth = get(handlerStyle, 'width', DEFAULT_HANDLER_WIDTH);
 
     // 设置文本
     minTextShape.attr('text', minText);
     maxTextShape.attr('text', maxText);
-
     const [minAttrs, maxAttrs] = this._dodgeText([min, max], minTextShape, maxTextShape);
     // 2. 左侧滑块和文字位置
     if (this.minHandler) {
+      const newStyle =
+        this.currentTarget === 'minHandler'
+          ? {
+              ...handlerStyle,
+              stroke: handlerStyle.highLightStroke,
+            }
+          : handlerStyle;
       this.minHandler.update({
         x: min - handlerWidth / 2,
+        style: newStyle,
       });
       if (!this.get('updateAutoRender')) {
         this.minHandler.render();
@@ -349,8 +359,16 @@ export class Slider extends GroupComponent<SliderCfg> implements ISlider {
 
     // 3. 右侧滑块和文字位置
     if (this.maxHandler) {
+      const newStyle =
+        this.currentTarget === 'maxHandler'
+          ? {
+              ...handlerStyle,
+              stroke: handlerStyle.highLightStroke,
+            }
+          : handlerStyle;
       this.maxHandler.update({
         x: max - handlerWidth / 2,
+        style: newStyle,
       });
       if (!this.get('updateAutoRender')) {
         this.maxHandler.render();
@@ -457,6 +475,25 @@ export class Slider extends GroupComponent<SliderCfg> implements ISlider {
     // 结束之后，取消绑定的事件
     if (this.currentTarget) {
       this.currentTarget = undefined;
+    }
+
+    // 清空handler的高亮状态
+    const { handlerStyle } = this.cfg;
+    if (this.minHandler && this.minHandler.cfg.style.stroke === handlerStyle.highLightStroke) {
+      this.minHandler.update({
+        style: handlerStyle,
+      });
+      if (!this.get('updateAutoRender')) {
+        this.minHandler.render();
+      }
+    }
+    if (this.maxHandler && this.maxHandler.cfg.style.stroke === handlerStyle.highLightStroke) {
+      this.maxHandler.update({
+        style: handlerStyle,
+      });
+      if (!this.get('updateAutoRender')) {
+        this.maxHandler.render();
+      }
     }
 
     const containerDOM = this.getContainerDOM();


### PR DESCRIPTION
### 改动点

设计体验优化

- 交换选中区域内框选和拖动的位置：用户的框选操作更倾向从上往下，框选放在下方更符合用户习惯。
<img width="562" alt="image" src="https://user-images.githubusercontent.com/109653633/220228642-8d51926f-df0c-4ae0-a808-8a287b50489c.png">

- 拖动过程中，保持住滑块的高亮颜色
![iShot_2023-02-21_10 03 04](https://user-images.githubusercontent.com/109653633/220228925-ed88f30d-84ed-44ea-9352-d274140be70e.gif)
