### PR TITLE
feat: dodgeText and brushRatio support receive from user

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/component",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "The component module for antv",
   "author": "https://github.com/orgs/antvis/people",
   "license": "MIT",

--- a/src/slider/constant.ts
+++ b/src/slider/constant.ts
@@ -37,6 +37,7 @@ export const FOREGROUND_STYLE = {
   stroke: '#4E83CD',
   strokeOpacity: 0.3,
   lineWidth: 0.8,
+  brushRatio: 3 / 4,
 };
 
 export const SLIDER_BAR_LINE_GAP = 4;
@@ -70,10 +71,10 @@ export const TEXT_STYLE = {
   textBaseline: 'middle',
   fill: '#000',
   opacity: 0.45,
+  padding: 2,
 };
 
 export const SLIDER_CHANGE = 'sliderchange';
 
 export const MAX_TEXT_WIDTH = 60;
-export const TEXT_PADDING = 2;
 export const TEXT_SAFE_WIDTH = 4;

--- a/src/slider/foreground.ts
+++ b/src/slider/foreground.ts
@@ -11,6 +11,8 @@ interface IStyle {
   opacity?: number;
   cursor?: string;
   highLightFill?: string;
+  /** 框选占比 */
+  brushRatio?: number;
 }
 
 export interface ForegroundCfg extends GroupComponentCfg {
@@ -38,6 +40,7 @@ export class Foreground extends GroupComponent<ForegroundCfg> {
 
   protected renderInner(group: IGroup) {
     const { x, height, width, foregroundStyle, barStyle } = this.cfg;
+    const { brushRatio } = foregroundStyle;
 
     // 上方移动区域
     this.addShape(group, {
@@ -48,7 +51,7 @@ export class Foreground extends GroupComponent<ForegroundCfg> {
         x,
         y: 0,
         width,
-        height: (height * 2) / 5,
+        height: height * (1 - brushRatio),
         cursor: 'move',
         ...omit(foregroundStyle, ['stroke']),
       },
@@ -61,9 +64,9 @@ export class Foreground extends GroupComponent<ForegroundCfg> {
       type: 'rect',
       attrs: {
         x,
-        y: (height * 2) / 5,
+        y: height * (1 - brushRatio),
         width,
-        height: (height * 3) / 5,
+        height: height * brushRatio,
         cursor: 'crosshair',
         ...omit(foregroundStyle, ['stroke']),
       },

--- a/src/slider/handler.ts
+++ b/src/slider/handler.ts
@@ -1,4 +1,5 @@
 import { IGroup } from '@antv/g-base';
+import { omit } from '@antv/util';
 import GroupComponent from '../abstract/group-component';
 import { GroupComponentCfg } from '../types';
 import { DEFAULT_HANDLER_HEIGHT, DEFAULT_HANDLER_WIDTH, HANDLER_STYLE } from './constant';
@@ -21,6 +22,7 @@ export interface HandlerCfg extends GroupComponentCfg {
   readonly height: number;
   // style
   readonly style?: IStyle;
+  readonly sliderHeight?: number;
 }
 
 export class Handler extends GroupComponent<HandlerCfg> {
@@ -37,10 +39,23 @@ export class Handler extends GroupComponent<HandlerCfg> {
     };
   }
   protected renderInner(group: IGroup) {
-    const { width, height, style } = this.cfg as HandlerCfg;
-    const { fill, stroke, radius, opacity, cursor } = style;
+    const { width, height, style, sliderHeight } = this.cfg;
+    const { stroke, cursor } = style;
 
-    // 按钮框框
+    // 滑块柄竖线
+    this.addShape(group, {
+      type: 'line',
+      id: this.getElementId('background-line'),
+      attrs: {
+        x1: (1 / 2) * width,
+        y1: -(sliderHeight - height) / 2,
+        x2: (1 / 2) * width,
+        y2: (height + sliderHeight) / 2,
+        stroke,
+      },
+    });
+
+    // 滑块柄框框
     this.addShape(group, {
       type: 'rect',
       id: this.getElementId('background'),
@@ -49,10 +64,7 @@ export class Handler extends GroupComponent<HandlerCfg> {
         y: 0,
         width,
         height,
-        fill,
-        radius,
-        opacity,
-        cursor,
+        ...omit(style, ['stroke']),
       },
     });
 
@@ -106,6 +118,7 @@ export class Handler extends GroupComponent<HandlerCfg> {
   private bindEvents() {
     this.get('group').on('mouseenter', () => {
       const { highLightStroke } = this.get('style');
+      this.getElementByLocalId('background-line').attr('stroke', highLightStroke);
       this.getElementByLocalId('line-left').attr('stroke', highLightStroke);
       this.getElementByLocalId('line-right').attr('stroke', highLightStroke);
       this.draw();
@@ -113,6 +126,7 @@ export class Handler extends GroupComponent<HandlerCfg> {
 
     this.get('group').on('mouseleave', () => {
       const { stroke } = this.get('style');
+      this.getElementByLocalId('background-line').attr('stroke', stroke);
       this.getElementByLocalId('line-left').attr('stroke', stroke);
       this.getElementByLocalId('line-right').attr('stroke', stroke);
       this.draw();

--- a/tests/unit/slider/handler-spec.ts
+++ b/tests/unit/slider/handler-spec.ts
@@ -36,12 +36,6 @@ describe('handler', () => {
     expect(handler.get('width')).toBe(8);
     expect(handler.get('height')).toBe(30);
 
-    // background
-    const background = handler.getElementByLocalId('background');
-    const backgroundBBox = background.getBBox();
-    expect(backgroundBBox.width).toBe(8);
-    expect(backgroundBBox.height).toBe(30);
-
     // left line
     const leftLine = handler.getElementByLocalId('line-left');
     const leftLineBBox = leftLine.getBBox();


### PR DESCRIPTION
#### 功能点

样式问题修复。业务方对这些属性的要求较多，所以改为支持可配置。

- 文本位置调整支持业务层定制：`textStyle.dodgeText`
- 刷选区域的占比支持业务层定制：`foregroundStyle.brushRatio`
- 添加滑块柄， `handler` 新增一条小竖线
- 文本间距支持业务层定制: `textStyle.padding`