### PR TITLE
Feat: add more datamarker annotation direction

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1219,7 +1219,7 @@ export interface DataMarkerAnnotationCfg extends GroupComponentCfg {
   /**
    * 方向
    */
-  direction?: 'upward' | 'downward';
+  direction?: 'upward' | 'downward' | 'leftward' | 'rightward';
   /**
    * 是否自动调整
    */

--- a/tests/unit/annotation/data-marker-spec.ts
+++ b/tests/unit/annotation/data-marker-spec.ts
@@ -87,6 +87,56 @@ describe('annotation data-marker', () => {
     expect(textGroup.attr('y')).toBeGreaterThan(pointShape.attr('y'));
   });
 
+  it('render leftward', () => {
+    dataMarker.update({
+      direction: 'leftward',
+    });
+
+    // group matrix
+    expect(dataMarker.get('group').attr('matrix')).toEqual([1, 0, 0, 0, 1, 0, 100, 150, 1]);
+
+    // point rendered
+    const pointShape: IShape = dataMarker.getElementByLocalId('point');
+    expect(pointShape).toBeDefined();
+
+    // line rendered
+    const lineShape: IShape = dataMarker.getElementByLocalId('line');
+    expect(lineShape).toBeDefined();
+
+    // text rendered
+    const textShape: IShape = dataMarker.getElementByLocalId('text');
+    expect(textShape.attr('text')).toBe('test text');
+
+    const textGroup = dataMarker.getElementByLocalId('text-group');
+    expect(textGroup.attr('x')).toBeLessThan(pointShape.attr('x'))
+    expect(textGroup.attr('y')).toBe(pointShape.attr('y'));
+  });
+
+  it('render rightward', () => {
+    dataMarker.update({
+      direction: 'rightward',
+    });
+
+    // group matrix
+    expect(dataMarker.get('group').attr('matrix')).toEqual([1, 0, 0, 0, 1, 0, 100, 150, 1]);
+
+    // point rendered
+    const pointShape: IShape = dataMarker.getElementByLocalId('point');
+    expect(pointShape).toBeDefined();
+
+    // line rendered
+    const lineShape: IShape = dataMarker.getElementByLocalId('line');
+    expect(lineShape).toBeDefined();
+
+    // text rendered
+    const textShape: IShape = dataMarker.getElementByLocalId('text');
+    expect(textShape.attr('text')).toBe('test text');
+
+    const textGroup = dataMarker.getElementByLocalId('text-group');
+    expect(textGroup.attr('x')).toBeGreaterThan(pointShape.attr('x'))
+    expect(textGroup.attr('y')).toBe(pointShape.attr('y'));
+  });
+
   it('render styled', () => {
     dataMarker.update({
       point: {


### PR DESCRIPTION
##### 变更描述
希望可以在0.8.x版本里 让dataMarker类型标注功能支持更多的朝向

- dataMarker类型标注功能支持更多的朝向：'leftward' | 'rightward'
- 对dataMarker类型标注的自动布局进行了优化

![image](https://user-images.githubusercontent.com/68099359/228777365-338c90c3-c7e0-449e-8482-5b12f29dd222.png)

![image](https://user-images.githubusercontent.com/68099359/228777907-c4bb6bef-957b-42c7-9a98-bf679cf5ab3c.png)
