### PR TITLE
feat: axis.label.formatter add more params for custom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+#### 0.9.5 (2023-05-04)
+
+##### New Features
+
+- axis.label.formatter add more params for custom ([1a818761](https://github.com/antvis/component/commit/1a818761b86a783a605180aca4df7161dcfff313))
+- textpadding and brushRatio support receive from user ([#296](https://github.com/antvis/component/pull/296)) ([61cf820a](https://github.com/antvis/component/commit/61cf820a84afcde8e5ab292b89ba214a87740fbc))
+
 #### 0.9.2 (2023-02-17)
 
 ##### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/component",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "The component module for antv",
   "author": "https://github.com/orgs/antvis/people",
   "license": "MIT",

--- a/src/axis/base.ts
+++ b/src/axis/base.ts
@@ -88,7 +88,7 @@ abstract class AxisBase<T extends AxisBaseCfg = AxisBaseCfg> extends GroupCompon
             fill: Theme.descriptionIconFill,
             stroke: Theme.descriptionIconStroke,
           },
-          description: ''
+          description: '',
         },
         tickStates: {
           active: {
@@ -480,7 +480,7 @@ abstract class AxisBase<T extends AxisBaseCfg = AxisBaseCfg> extends GroupCompon
     const { offset, offsetX, offsetY, rotate, formatter } = labelCfg;
     const point = this.getSidePoint(tick.point, offset);
     const vector = this.getSideVector(offset, point);
-    const text = formatter ? formatter(tick.name, tick, index) : tick.name;
+    const text = formatter ? formatter(tick.name, tick, index, ticks) : tick.name;
     let { style } = labelCfg;
     style = isFunction(style) ? get(this.get('theme'), ['label', 'style'], {}) : style;
 
@@ -583,25 +583,25 @@ abstract class AxisBase<T extends AxisBaseCfg = AxisBaseCfg> extends GroupCompon
       type: 'text',
       id: this.getElementId('title'),
       name: 'axis-title',
-      attrs: titleAttrs
+      attrs: titleAttrs,
     });
     // description字段存在时，显示icon
-    if(this.get('title')?.description) {
-      this.drawDescriptionIcon(group, titleShape, titleAttrs.matrix)
+    if (this.get('title')?.description) {
+      this.drawDescriptionIcon(group, titleShape, titleAttrs.matrix);
     }
   }
 
   private drawDescriptionIcon(group: IGroup, titleShape: IShape, matrix: number[]) {
     const descriptionShape = this.addGroup(group, {
       name: 'axis-description',
-      id: this.getElementById('description')
-    })
+      id: this.getElementById('description'),
+    });
 
     const { maxX, maxY, height } = titleShape.getBBox();
-    const { iconStyle } = this.get('title')
+    const { iconStyle } = this.get('title');
     const spacing = 4; // 设置icon与文本之间距离
     const r = height / 2;
-    const lineWidth =  r / 6;
+    const lineWidth = r / 6;
     const startX = maxX + spacing;
     const startY = maxY - height / 2;
     // 绘制 information icon 路径
@@ -614,7 +614,7 @@ abstract class AxisBase<T extends AxisBaseCfg = AxisBaseCfg> extends GroupCompon
     const [x4, y4] = [startX + r, startY - height / 4];
     const [x5, y5] = [x4, y4 + lineWidth];
     const [x6, y6] = [x5, y5 + lineWidth];
-    const [x7, y7] = [x6, y6 + r * 3 / 4];
+    const [x7, y7] = [x6, y6 + (r * 3) / 4];
     this.addShape(descriptionShape, {
       type: 'path',
       id: this.getElementId('title-description-icon'),
@@ -629,11 +629,11 @@ abstract class AxisBase<T extends AxisBaseCfg = AxisBaseCfg> extends GroupCompon
           ['M', x4, y4],
           ['L', x5, y5],
           ['M', x6, y6],
-          ['L', x7, y7]
+          ['L', x7, y7],
         ],
         lineWidth,
         matrix,
-        ...iconStyle
+        ...iconStyle,
       },
     });
     // 点击热区，设置透明矩形
@@ -650,10 +650,9 @@ abstract class AxisBase<T extends AxisBaseCfg = AxisBaseCfg> extends GroupCompon
         fill: '#000',
         opacity: 0,
         matrix,
-        cursor: 'pointer'
-      }
-    })
-
+        cursor: 'pointer',
+      },
+    });
   }
 
   private applyTickStates(tick, group) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -811,7 +811,7 @@ export interface LegendItemNameCfg {
   style?: ShapeAttrs | ShapeAttrsCallback;
 }
 
-type formatterCallback = (text: string, item: ListItem, index: number) => any;
+type formatterCallback = (text: string, item: ListItem, index: number, items?: ListItem[]) => any;
 
 export interface LegendItemValueCfg {
   /**

--- a/tests/unit/axis/circle-spec.ts
+++ b/tests/unit/axis/circle-spec.ts
@@ -76,6 +76,18 @@ describe('test line axis', () => {
     expect(label1.attr('text')).toBe('1%');
   });
 
+  it('label formatter params', () => {
+    axis.update({
+      label: {
+        formatter: (text, tick, index, ticks) => {
+          // @ts-ignore
+          expect(ticks[index]).toBe(tick);
+          return text + '%';
+        },
+      },
+    });
+  });
+
   it('update title', () => {
     expect(axis.getElementById('a-axis-title')).toBeUndefined();
     axis.update({


### PR DESCRIPTION
#### 功能描述

业务需要根据轴标签之间的间距来决定显示的文本长度和换行，所以业务方需要通过 formatter 函数得到轴间距。
因此，在 `axis.label.formatter` 中加入 ticks 参数，能够得到前后 label 的坐标信息。可以根据坐标信息得到轴间距。
```js
axis.label.formatter: (text, tick, index, ticks) => {
  const newPoint = ticks[index+1].point; // 下一个 label 坐标
  const curPoint = tick.point; // 当前 label 坐标
  const interval = newPoint.x - curPoint.x;
  // 处理换行...
  return newText;
}
```

<img width="1040" alt="image" src="https://user-images.githubusercontent.com/109653633/236122501-0604703c-d832-4618-a038-c239b9e273b5.png">
