### PR TITLE
fix: 修复datamarker自动调整下文本与文本背景偏移存在偏差

### DIFF
--- a/src/annotation/data-marker.ts
+++ b/src/annotation/data-marker.ts
@@ -145,12 +145,11 @@ class DataMarkerAnnotation extends GroupComponent<DataMarkerAnnotationCfg> imple
 
     if (textGroup) {
       let translateX = textGroup.attr('x'), translateY = textGroup.attr('y');
-      let textBaseline, textAlign;
+      let { width, height } = textShape.getCanvasBBox();
       let xFactor = 0, yFactor = 0;
       if (x + minX <= coordinateBBox.minX) {
         // 左侧超出
         if (direction === 'leftward') {
-          textAlign = 'start';
           xFactor = 1;
         } else {
           const overflow = coordinateBBox.minX - (x + minX);
@@ -159,27 +158,24 @@ class DataMarkerAnnotation extends GroupComponent<DataMarkerAnnotationCfg> imple
       } else if (x + maxX >= coordinateBBox.maxX) {
         // 右侧超出
         if (direction === 'rightward') {
-          textAlign = 'end';
           xFactor = -1;
         } else {
           const overflow = x + maxX - coordinateBBox.maxX;
           translateX = textGroup.attr('x') - overflow;
         }
       }
-      if (!!xFactor && textAlign) {
-        textShape.attr('textAlign', textAlign);
+      if (!!xFactor) {
         if (lineShape) {
           lineShape.attr('path', [
             ['M', 0, 0],
             ['L', lineLength * xFactor, 0],
           ]);
         }
-        translateX = (lineLength + 2) * xFactor;
+        translateX = (lineLength + 2 + width) * xFactor;
       }
       if (y + minY <= coordinateBBox.minY) {
         // 上方超出
         if (direction === 'upward') {
-          textBaseline = 'top';
           yFactor = 1;
         } else {
           const overflow = coordinateBBox.minY - (y + minY);
@@ -188,22 +184,20 @@ class DataMarkerAnnotation extends GroupComponent<DataMarkerAnnotationCfg> imple
       } else if (y + maxY >= coordinateBBox.maxY) {
         // 下方超出
         if (direction === 'downward') {
-          textBaseline = 'bottom';
           yFactor = -1;
         } else {
           const overflow = y + maxY - coordinateBBox.maxY;
           translateY = textGroup.attr('y') - overflow;
         }
       }
-      if (!!yFactor && textBaseline) {
-        textShape.attr('textBaseline', textBaseline);
+      if (!!yFactor) {
         if (lineShape) {
           lineShape.attr('path', [
             ['M', 0, 0],
             ['L', 0, lineLength * yFactor],
           ]);
         }
-        translateY = (lineLength + 2) * yFactor;
+        translateY = (lineLength + 2 + height) * yFactor;
       }
       if (translateX !== textGroup.attr('x') || translateY !== textGroup.attr('y'))
         applyTranslate(textGroup, translateX, translateY);
@@ -247,7 +241,7 @@ class DataMarkerAnnotation extends GroupComponent<DataMarkerAnnotationCfg> imple
       line: {
         path: [
           ['M', 0, 0],
-          ['L', 0, lineLength * xFactor, lineLength * yFactor],
+          ['L', lineLength * xFactor, lineLength * yFactor],
         ],
         ...lineStyle,
       },

--- a/tests/unit/annotation/data-marker-spec.ts
+++ b/tests/unit/annotation/data-marker-spec.ts
@@ -294,6 +294,44 @@ describe('annotation data-marker', () => {
     expect(textGroup.getCanvasBBox().minX).toBe(0);
   });
 
+  it('render left side beyond with autoAdjust', () => {
+    dataMarker.update({
+      x: 10,
+      y: 150,
+      autoAdjust: true,
+      direction: 'upward',
+      coordinateBBox,
+      point: {},
+      line: {},
+      text: {
+        content: 'test text',
+      },
+    });
+
+    const textGroup = dataMarker.getElementByLocalId('text-group');
+    const pointShape: IShape = dataMarker.getElementByLocalId('point');
+    expect(textGroup.getCanvasBBox().x).toBeGreaterThan(pointShape.attr('x'));
+  });
+
+  it('render bottom side beyond with autoAdjust', () => {
+    dataMarker.update({
+      x: 100,
+      y: 480,
+      direction: 'downward',
+      autoAdjust: true,
+      coordinateBBox,
+      point: {},
+      line: {},
+      text: {
+        content: 'test text',
+      },
+    });
+
+    const pointShape: IShape = dataMarker.getElementByLocalId('point');
+    const textShape: IShape = dataMarker.getElementByLocalId('text');
+    expect(textShape.getCanvasBBox().y).toBeGreaterThan(pointShape.attr('y'));
+  });
+
   it('render left side beyond, with background and auto ellipsis', () => {
     dataMarker.update({
       x: 10,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### 变更描述
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- dataMarker类型标注连线的绘制进行了修复
- 对dataMarker类型标注的自动布局进行了优化

###### 自动布局优化前
![image](https://user-images.githubusercontent.com/68099359/236598373-f85e9e3c-0a84-4a43-b5d4-43c6acc68789.png)

###### 自动布局优化后
![image](https://user-images.githubusercontent.com/68099359/236598336-23548a88-2fa6-43a6-b309-8fbe071d331e.png)
 
