### PR TITLE
feat: add cfg in formatter params

### DIFF
--- a/src/axis/base.ts
+++ b/src/axis/base.ts
@@ -480,7 +480,7 @@ abstract class AxisBase<T extends AxisBaseCfg = AxisBaseCfg> extends GroupCompon
     const { offset, offsetX, offsetY, rotate, formatter } = labelCfg;
     const point = this.getSidePoint(tick.point, offset);
     const vector = this.getSideVector(offset, point);
-    const text = formatter ? formatter(tick.name, tick, index, ticks) : tick.name;
+    const text = formatter ? formatter(tick.name, tick, index, ticks, this.cfg) : tick.name;
     let { style } = labelCfg;
     style = isFunction(style) ? get(this.get('theme'), ['label', 'style'], {}) : style;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -811,7 +811,7 @@ export interface LegendItemNameCfg {
   style?: ShapeAttrs | ShapeAttrsCallback;
 }
 
-type formatterCallback = (text: string, item: ListItem, index: number, items?: ListItem[]) => any;
+type formatterCallback = (text: string, item: ListItem, index: number, items?: ListItem[], cfg?: BaseCfg) => any;
 
 export interface LegendItemValueCfg {
   /**

--- a/tests/unit/axis/circle-spec.ts
+++ b/tests/unit/axis/circle-spec.ts
@@ -79,9 +79,9 @@ describe('test line axis', () => {
   it('label formatter params', () => {
     axis.update({
       label: {
-        formatter: (text, tick, index, ticks) => {
-          // @ts-ignore
-          expect(ticks[index]).toBe(tick);
+        formatter: (text, tick, index, ticks, cfg) => {
+          expect(ticks![index]).toBe(tick);
+          expect(cfg!.start).toBe(axis.get('start'));
           return text + '%';
         },
       },


### PR DESCRIPTION
#### 功能描述

极端场景，当图表仅有一个一条数据时。坐标轴标签超长情况处理需要根据X轴整体宽度决定。所以提供 cfg 参数，供业务层做定制。

```js
xAxis: {
  label: {
     formatter: (text, tick, index, ticks, cfg) => {
       const { start, end } = cfg;
       const axisWidth = Math.abs(end.x - start.x);
       // handle ellipse
     }
  }
}
```
<img width="300" alt="image" src="https://github.com/antvis/component/assets/109653633/d5836b44-fdc7-4f7b-9971-fc1e5de5b5b3">
