### PR TITLE
fix: provide a mock function to measure text width

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/component",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "Visualization components for AntV, based on G.",
   "license": "MIT",
   "main": "lib/index.js",

--- a/src/util/text.ts
+++ b/src/util/text.ts
@@ -2,6 +2,11 @@ import { isString, memoize } from '@antv/util';
 import type { DisplayObject, Text } from '../shapes';
 
 let ctx: CanvasRenderingContext2D;
+let mockMeasureTextWidth: ((text: string, fontSize: number) => number) | undefined;
+
+export function setMockMeasureTextWidth(mock: (text: string, fontSize: number) => number) {
+  mockMeasureTextWidth = mock;
+}
 
 /**
  * 计算文本在画布中的宽度
@@ -10,6 +15,11 @@ export const measureTextWidth = memoize(
   (text: string | Text, font?: any): number => {
     const content = isString(text) ? text : text.style.text.toString();
     const { fontSize, fontFamily, fontWeight, fontStyle, fontVariant } = font || getFont(text as Text);
+
+    if (mockMeasureTextWidth) {
+      return mockMeasureTextWidth(content, fontSize);
+    }
+
     if (!ctx) {
       ctx = document.createElement('canvas').getContext('2d') as CanvasRenderingContext2D;
     }


### PR DESCRIPTION
使用 document 创建 `<canvas>` 进行文本连弟度量，会导致服务端渲染强依赖 node-canvas。
此时可以参考 plot 使用一个字符宽度查找表进行估算，因此需要提供一个可传入的 mock 方法实现：

```ts
import { setMockMeasureTextWidth } from '@antv/component';
setMockMeasureTextWidth(measureText);
```

目前 G2 在截图测试中使用。