### PR TITLE
fix: change the scrollbar and legend hover style.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/component",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0",
   "description": "Visualization components for AntV, based on G.",
   "license": "MIT",
   "main": "lib/index.js",

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -19,8 +19,8 @@ export type PrefixStyleProps<T extends Record<string, any>, P extends string> = 
   [K in keyof T as K extends `show${infer S}`
     ? `show${Capitalize<P>}${S}`
     : K extends string
-    ? `${P}${Capitalize<K>}`
-    : never]: T[K];
+      ? `${P}${Capitalize<K>}`
+      : never]: T[K];
 };
 
 export type CallableStyleProps<T extends Record<string, any>, P extends any[]> = {

--- a/src/ui/legend/continuous.ts
+++ b/src/ui/legend/continuous.ts
@@ -2,7 +2,7 @@ import { CustomEvent } from '@antv/g';
 import { Linear } from '@antv/scale';
 import { clamp, isUndefined } from '@antv/util';
 import { Component } from '../../core';
-import type { DisplayObject, TextStyleProps } from '../../shapes';
+import type { BaseStyleProps, DisplayObject, TextStyleProps } from '../../shapes';
 import { Group } from '../../shapes';
 import { Point } from '../../types';
 import {
@@ -45,6 +45,7 @@ function getMinMax(data: ContinuousDatum[]) {
 
 export class Continuous extends Component<ContinuousStyleProps> {
   constructor(options: ContinuousOptions) {
+    console.log('continunes');
     super(options, CONTINUOUS_DEFAULT_OPTIONS);
   }
 
@@ -322,6 +323,8 @@ export class Continuous extends Component<ContinuousStyleProps> {
               this.update({ labelText });
               const name = `${type}Handle` as `${HandleType}Handle`;
               that[name] = this;
+              this.addEventListener('pointerover', that.changeCursor('pointer'));
+              this.addEventListener('pointerleave', that.changeCursor('default'));
               this.addEventListener('pointerdown', that.onDragStart(type));
             }),
         (update) =>
@@ -736,5 +739,11 @@ export class Continuous extends Component<ContinuousStyleProps> {
       detail: { value, range },
     });
     this.dispatchEvent(evt as any);
+  }
+
+  private changeCursor(cursor: BaseStyleProps['cursor'] = 'default') {
+    return (e: any) => {
+      this.style.cursor = cursor;
+    };
   }
 }

--- a/src/ui/legend/continuous.ts
+++ b/src/ui/legend/continuous.ts
@@ -569,11 +569,11 @@ export class Continuous extends Component<ContinuousStyleProps> {
   private prevValue!: number;
 
   public bindEvents() {
+    this.style.cursor = 'pointer';
     // 绑定 drag 开始事件
     this.ribbon.on('pointerdown', this.onDragStart('ribbon'));
     this.ribbon.on('pointermove', this.onHovering);
     this.addEventListener('pointerout', this.hideIndicator);
-    this.addEventListener('pointerover', this.changeCursor('pointer'));
   }
 
   private onHovering = (e: any) => {
@@ -737,11 +737,5 @@ export class Continuous extends Component<ContinuousStyleProps> {
       detail: { value, range },
     });
     this.dispatchEvent(evt as any);
-  }
-
-  private changeCursor(cursor: BaseStyleProps['cursor'] = 'default') {
-    return (e: any) => {
-      this.style.cursor = cursor;
-    };
   }
 }

--- a/src/ui/legend/continuous.ts
+++ b/src/ui/legend/continuous.ts
@@ -323,7 +323,7 @@ export class Continuous extends Component<ContinuousStyleProps> {
               const name = `${type}Handle` as `${HandleType}Handle`;
               that[name] = this;
               this.addEventListener('pointerover', that.changeCursor('pointer'));
-              this.addEventListener('pointerleave', that.changeCursor('default'));
+              // this.addEventListener('pointerleave', that.changeCursor('default'));
               this.addEventListener('pointerdown', that.onDragStart(type));
             }),
         (update) =>
@@ -575,6 +575,7 @@ export class Continuous extends Component<ContinuousStyleProps> {
     this.ribbon.on('pointerdown', this.onDragStart('ribbon'));
     this.ribbon.on('pointermove', this.onHovering);
     this.addEventListener('pointerout', this.hideIndicator);
+    this.addEventListener('pointerover', this.changeCursor('pointer'));
   }
 
   private onHovering = (e: any) => {
@@ -651,7 +652,7 @@ export class Continuous extends Component<ContinuousStyleProps> {
   };
 
   private onDragEnd = () => {
-    this.style.cursor = 'default';
+    this.style.cursor = 'pointer';
     document.removeEventListener('mousemove', this.onDragging);
     document.removeEventListener('touchmove', this.onDragging);
     document.removeEventListener('mouseup', this.onDragEnd);

--- a/src/ui/legend/continuous.ts
+++ b/src/ui/legend/continuous.ts
@@ -322,8 +322,6 @@ export class Continuous extends Component<ContinuousStyleProps> {
               this.update({ labelText });
               const name = `${type}Handle` as `${HandleType}Handle`;
               that[name] = this;
-              this.addEventListener('pointerover', that.changeCursor('pointer'));
-              // this.addEventListener('pointerleave', that.changeCursor('default'));
               this.addEventListener('pointerdown', that.onDragStart(type));
             }),
         (update) =>

--- a/src/ui/legend/continuous.ts
+++ b/src/ui/legend/continuous.ts
@@ -45,7 +45,6 @@ function getMinMax(data: ContinuousDatum[]) {
 
 export class Continuous extends Component<ContinuousStyleProps> {
   constructor(options: ContinuousOptions) {
-    console.log('continunes');
     super(options, CONTINUOUS_DEFAULT_OPTIONS);
   }
 

--- a/src/ui/slider/index.ts
+++ b/src/ui/slider/index.ts
@@ -287,8 +287,8 @@ export class Slider extends Component<SliderStyleProps> {
                 this.addEventListener('pointerdown', () => {
                   this.attr('cursor', 'grabbing');
                 });
-                this.addEventListener('pointerup', () => {
-                  this.attr('cursor', 'grab');
+                this.addEventListener('pointerover', () => {
+                  this.attr('cursor', 'pointer');
                 });
               } else {
                 this.on('pointerdown', that.onDragStart('track'));

--- a/src/ui/slider/index.ts
+++ b/src/ui/slider/index.ts
@@ -287,6 +287,9 @@ export class Slider extends Component<SliderStyleProps> {
                 this.addEventListener('pointerdown', () => {
                   this.attr('cursor', 'grabbing');
                 });
+                this.addEventListener('pointerup', () => {
+                  this.attr('cursor', 'pointer');
+                });
                 this.addEventListener('pointerover', () => {
                   this.attr('cursor', 'pointer');
                 });


### PR DESCRIPTION
- ref https://github.com/antvis/G2/issues/5791
- [x] change the scrollbar, legend hover style to the `cursor: pointer` when draggable.
- [x] run `npm run test` 

* before 
<img width="375" alt="image" src="https://github.com/antvis/component/assets/48038769/b8879825-6a57-468a-bf6b-eb4d071d9296">
<img width="515" alt="image" src="https://github.com/antvis/component/assets/48038769/972d0d8e-09bb-4e44-a891-f42555896543">

* after
<img width="333" alt="image" src="https://github.com/antvis/component/assets/48038769/5d5207fe-eb81-459c-8b56-a4084474ab5b">
<img width="473" alt="image" src="https://github.com/antvis/component/assets/48038769/898a15be-c703-434d-ab68-8c2bcdc90901">
 
* the issue: [legend、slider、scrollbar 涉及到鼠标拖拽的，都需要设置鼠标样式为手型 ](https://github.com/antvis/G2/issues/5791)