### PR TITLE
fix: trigger scroll event on mouse wheel

### DIFF
--- a/src/ui/slider/index.ts
+++ b/src/ui/slider/index.ts
@@ -511,13 +511,12 @@ export class Slider extends Component<SliderStyleProps> {
     return orientation === 'horizontal' ? x : y;
   }
 
-  private setValuesOffset(stOffset: number, endOffset: number = 0, animate: boolean = false) {
+  private setValuesOffset(stOffset: number, endOffset: number = 0) {
     const { type } = this.attributes;
     const [oldStartVal, oldEndVal] = this.getValues();
     const internalStartOffset = type === 'range' ? stOffset : 0;
     const values = [oldStartVal + internalStartOffset, oldEndVal + endOffset].sort() as [number, number];
-    if (animate) this.setValues(values);
-    else this.innerSetValues(values, true);
+    this.innerSetValues(values, true);
   }
 
   private getRatio(val: number) {
@@ -550,7 +549,7 @@ export class Slider extends Component<SliderStyleProps> {
       const offset = deltaY || deltaX;
       const deltaVal = this.getRatio(offset);
 
-      this.setValuesOffset(deltaVal, deltaVal, true);
+      this.setValuesOffset(deltaVal, deltaVal);
     }
   }
 


### PR DESCRIPTION
问题描述：我在使用G2 ，通过 scrollable 属性开启滚轮滚动，但是滚动条滚动了内容缺没有滚动。
问题原因：这里设置了一个 `animate` 变量，在 `onScroll` 触发时没有去触发更新事件。[源码](https://github.com/antvis/component/blame/master/src/ui/slider/index.ts#L553)
通过打印可以发现 `onScroll` 与 `onDragging` 是分开执行的。如果原本是为了避免频繁触发，这里也应该是用个`节流` 。
![钉钉录屏_2025-08-11 170037](https://github.com/user-attachments/assets/30345099-a84f-491d-a87d-2b23c645238b)