### PR TITLE
feat: add legend focus icon

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,13 @@
 {
-  "cSpell.words": ["bbox", "Sparkline", "timebar"],
-  "svg.preview.background": "white"
+  "cSpell.words": [
+    "bbox",
+    "Sparkline",
+    "timebar"
+  ],
+  "svg.preview.background": "white",
+  "projectConfig": {
+    "dima": {
+      "installedvscode": true
+    }
+  }
 }

--- a/__tests__/integration/snapshots/Marker1.svg
+++ b/__tests__/integration/snapshots/Marker1.svg
@@ -104,17 +104,22 @@
         </g>
         <g fill="none" transform="matrix(.7071 .7071 -.7071 .7071 182.6346 59.0812)">
           <g>
-            <path fill="none" stroke="rgba(0,0,255,1)" stroke-width="2" d="m12 238.8 16 0 0 22.4-16 0Z" class="marker path-marker"/>
+            <path fill="none" stroke="rgba(0,0,255,1)" stroke-width="2" d="M12 250a8 8 0 1 0 16 0 8 8 0 1 0-16 0Zm2.4 0 4 0m3.2 0 4 0m-5.6-5.6 0 4m0 3.2 0 4" class="marker path-marker"/>
           </g>
         </g>
         <g fill="none" transform="matrix(.7071 .7071 -.7071 .7071 197.2792 23.7258)">
           <g>
-            <path fill="none" stroke="rgba(0,0,255,1)" stroke-width="2" d="m70 250 4.48 4 6.72 0 0-8-6.72 0Zm4.48 1.3333 4.72 0m-4.72-2.6666 4.72 0" class="marker path-marker"/>
+            <path fill="none" stroke="rgba(0,0,255,1)" stroke-width="2" d="m62 238.8 16 0 0 22.4-16 0Z" class="marker path-marker"/>
           </g>
         </g>
         <g fill="none" transform="matrix(.7071 .7071 -.7071 .7071 211.9239 -11.6295)">
           <g>
-            <path fill="none" stroke="rgba(0,0,255,1)" stroke-width="2" d="m120 250-4 4.48 0 6.72 8 0 0-6.72Zm-1.3333 4.48 0 4.72m2.6666-4.72 0 4.72" class="marker path-marker"/>
+            <path fill="none" stroke="rgba(0,0,255,1)" stroke-width="2" d="m120 250 4.48 4 6.72 0 0-8-6.72 0Zm4.48 1.3333 4.72 0m-4.72-2.6666 4.72 0" class="marker path-marker"/>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(.7071 .7071 -.7071 .7071 226.5685 -46.9848)">
+          <g>
+            <path fill="none" stroke="rgba(0,0,255,1)" stroke-width="2" d="m170 250-4 4.48 0 6.72 8 0 0-6.72Zm-1.3333 4.48 0 4.72m2.6666-4.72 0 4.72" class="marker path-marker"/>
           </g>
         </g>
       </g>

--- a/docs/components/legend.md
+++ b/docs/components/legend.md
@@ -29,6 +29,8 @@ import { Category, Continuous } from '@antv/component';
 | gridCol      | `number`               | 每列显示的图例项个数                                    | `-`        |
 | rowPadding   | `number`               | 图例项之间的行间距                                      | `0`        |
 | colPadding   | `number`               | 图例项之间的列间距                                      | `0`        |
+| focus   | `boolean`               | 是否开启聚焦                                      | `-`        |
+| focusMarkerSize   | `number`               | 聚焦图标尺寸                                      | `12`        |
 | click        | `ClickEvent`           | 点击事件                                                | `-`        |
 | mouseenter   | `MouseEnterEvent`      | 鼠标移入事件                                            | `-`        |
 | mouseleave   | `MouseLeaveEvent`      | 鼠标移出事件                                            | `-`        |

--- a/src/ui/legend/category/item.ts
+++ b/src/ui/legend/category/item.ts
@@ -8,6 +8,7 @@ import {
   RectStyleProps,
   TextStyleProps,
 } from '@antv/g';
+import { isUndefined } from '@antv/util';
 import { Marker } from '../../marker';
 import type { ComponentOptions } from '../../../core';
 import { Component } from '../../../core';
@@ -170,24 +171,23 @@ export class CategoryItem extends Component<CategoryItemStyleProps> {
     const actualSpace = this.actualSpace;
     const { markerWidth, focusWidth, height } = actualSpace;
     let { labelWidth, valueWidth } = this.actualSpace;
-    const [spacing1, spacing2] = this.spacing;
+    const [spacing1, spacing2, spacing3] = this.spacing;
 
     if (fullWidth) {
-      const width = fullWidth - markerSize - spacing1 - spacing2 - focusWidth;
+      const width = fullWidth - markerSize - spacing1 - spacing2 - focusWidth - spacing3;
       const [span1, span2] = this.span;
       [labelWidth, valueWidth] = [span1 * width, span2 * width];
     }
 
-    const width = markerWidth + labelWidth + valueWidth + spacing1 + spacing2 + focusWidth;
+    const width = markerWidth + labelWidth + valueWidth + spacing1 + spacing2 + focusWidth + spacing3;
     return { width, height, markerWidth, labelWidth, valueWidth, focusWidth };
   }
 
   private get spacing() {
-    const { spacing } = this.attributes;
+    const { spacing, focus } = this.attributes;
     if (!spacing) return [0, 0, 0];
     const [spacing1, spacing2, spacing3] = parseSeriesAttr(spacing);
-    if (this.showValue) return [spacing1, spacing2, spacing3];
-    return [spacing1, 0, spacing3];
+    return [spacing1, this.showValue ? spacing2 : 0, focus ? spacing3 : 0];
   }
 
   private get layout() {
@@ -204,7 +204,7 @@ export class CategoryItem extends Component<CategoryItemStyleProps> {
         markerWidth / 2,
         markerWidth + spacing1,
         markerWidth + labelWidth + spacing1 + spacing2,
-        markerWidth + labelWidth + valueWidth + spacing1 + spacing2 + spacing3,
+        markerWidth + labelWidth + valueWidth + spacing1 + spacing2 + spacing3 + focusWidth / 2,
       ],
     };
   }
@@ -313,6 +313,8 @@ export class CategoryItem extends Component<CategoryItemStyleProps> {
       lineWidth: 1,
     };
 
+    if (isUndefined(focus)) return;
+
     this.focusGroup = ctn.maybeAppendByClassName<Group>(CLASS_NAMES.focusGroup, 'g').style('zIndex', 0);
     ifShow(focus, this.focusGroup, () => {
       const marker = new Marker({
@@ -379,7 +381,7 @@ export class CategoryItem extends Component<CategoryItemStyleProps> {
       transform: `translate(${markerX}, ${halfHeight})${this.markerGroup.node().style._transform}`,
     });
     this.labelGroup.styles({ transform: `translate(${labelX}, ${halfHeight})` });
-    this.focusGroup.styles({ transform: `translate(${focusX}, ${halfHeight})` });
+    if (this.focusGroup) this.focusGroup.styles({ transform: `translate(${focusX}, ${halfHeight})` });
 
     ellipsisIt(this.labelGroup.select(CLASS_NAMES.label.class).node(), Math.ceil(labelWidth));
     if (this.showValue) {

--- a/src/ui/legend/category/item.ts
+++ b/src/ui/legend/category/item.ts
@@ -306,7 +306,7 @@ export class CategoryItem extends Component<CategoryItemStyleProps> {
       x: 0,
       y: 0,
       size: focusMarkerSize,
-      opacity: 1,
+      opacity: 0.6,
       symbol: 'focus',
       stroke: '#aaaaaa',
       lineWidth: 1,
@@ -320,7 +320,6 @@ export class CategoryItem extends Component<CategoryItemStyleProps> {
         style: {
           ...defaultOptions,
           symbol: 'focus',
-          opacity: 0.6,
         },
       });
       const interactiveCircle = new Circle({

--- a/src/ui/legend/category/item.ts
+++ b/src/ui/legend/category/item.ts
@@ -111,7 +111,6 @@ export class CategoryItem extends Component<CategoryItemStyleProps> {
       valueFontSize: 12,
       labelTextBaseline: 'middle',
       valueTextBaseline: 'middle',
-      focus: false,
     });
   }
 

--- a/src/ui/legend/category/items.ts
+++ b/src/ui/legend/category/items.ts
@@ -55,6 +55,8 @@ export type CategoryItemsStyleProps = GroupStyleProps &
     mouseenter?: (el: Selection) => void;
     mouseleave?: (el: Selection) => void;
     poptip?: PoptipStyleProps & PoptipRender;
+    focus?: boolean;
+    focusMarkerSize?: number;
   };
 
 export type CategoryItemsOptions = ComponentOptions<CategoryItemsStyleProps>;
@@ -129,7 +131,7 @@ export class CategoryItems extends Component<CategoryItemsStyleProps> {
   }
 
   private get renderData() {
-    const { data, layout, poptip } = this.attributes;
+    const { data, layout, poptip, focus, focusMarkerSize } = this.attributes;
     const style = subStyleProps<CategoryItemStyleProps>(this.attributes, 'item');
 
     const d = data.map((datum, index) => {
@@ -142,6 +144,8 @@ export class CategoryItems extends Component<CategoryItemsStyleProps> {
           labelText,
           valueText,
           poptip,
+          focus,
+          focusMarkerSize,
           ...Object.fromEntries(
             Object.entries(style).map(([key, val]) => [key, getCallbackValue(val, [datum, index, data])])
           ),

--- a/src/ui/marker/index.ts
+++ b/src/ui/marker/index.ts
@@ -12,6 +12,7 @@ import {
   hexagon,
   hv,
   hvh,
+  focus,
   hyphen,
   line,
   plus,
@@ -122,3 +123,4 @@ Marker.registerSymbol('hv', hv);
 Marker.registerSymbol('vh', vh);
 Marker.registerSymbol('hvh', hvh);
 Marker.registerSymbol('vhv', vhv);
+Marker.registerSymbol('focus', focus);

--- a/src/ui/marker/symbol.ts
+++ b/src/ui/marker/symbol.ts
@@ -195,3 +195,27 @@ export function vhv(x: number, y: number) {
 export const button: SymbolFactor = (x, y, r) => {
   return [['M', x - r, y - r], ['L', x + r, y], ['L', x - r, y + r], ['Z']];
 };
+
+export const focus: SymbolFactor = (x, y, r) => {
+  const outerRadius = r;
+  const innerRadius = r * 0.2;
+  const crossLength = r * 0.7;
+
+  return [
+    // 外圆
+    ['M', x - outerRadius, y],
+    ['A', outerRadius, outerRadius, 0, 1, 0, x + outerRadius, y],
+    ['A', outerRadius, outerRadius, 0, 1, 0, x - outerRadius, y],
+    ['Z'],
+    // 水平十字线 (简单线条)
+    ['M', x - crossLength, y],
+    ['L', x - innerRadius, y],
+    ['M', x + innerRadius, y],
+    ['L', x + crossLength, y],
+    // 垂直十字线 (简单线条)
+    ['M', x, y - crossLength],
+    ['L', x, y - innerRadius],
+    ['M', x, y + innerRadius],
+    ['L', x, y + crossLength],
+  ];
+};


### PR DESCRIPTION
category 增加 focus icon
和 legend maker 相同，图形在 component 定义，事件在 g2 绑定

![Aug-21-2025 10-54-41](https://github.com/user-attachments/assets/7909eb58-7f22-4499-a054-3726397c1ead)

在 g2 中配置示例
```
.legend({
  focus: true,
  focusMarkerSize: 12
})
```



